### PR TITLE
Add static directory for web assets

### DIFF
--- a/src/simulation_tools/setup.py
+++ b/src/simulation_tools/setup.py
@@ -15,6 +15,7 @@ setup(
         (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*.py'))),
         (os.path.join('share', package_name, 'config'), glob(os.path.join('config', '*'))),
         (os.path.join('share', package_name, 'templates'), glob(os.path.join('templates', '*.html'))),
+        (os.path.join('share', package_name, 'static'), glob(os.path.join('static', '*'))),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -264,7 +264,7 @@ class WebInterfaceNode(Node):
         
         @self.app.route('/static/<path:path>')
         def serve_static(path):
-            return send_from_directory(os.path.join(os.path.dirname(__file__), 'static'), path)
+            return send_from_directory(self.app.static_folder, path)
     
     def setup_socketio_events(self):
         @self.socketio.on('connect')

--- a/src/simulation_tools/static/main.js
+++ b/src/simulation_tools/static/main.js
@@ -1,0 +1,2 @@
+// Placeholder script for simulation tools web interface
+console.log('Simulation tools static JS loaded');

--- a/src/simulation_tools/static/style.css
+++ b/src/simulation_tools/static/style.css
@@ -1,0 +1,2 @@
+/* Placeholder style file for simulation tools web interface */
+body { margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary
- include new `static` folder in setup
- allow `web_interface_node.py` to serve from Flask's static folder
- add placeholder JS and CSS files

## Testing
- `pytest -q src/simulation_tools/test` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68445ecbc49c833187e2299e45b95c17