### PR TITLE
Fix workspace setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
 1. **Installation**
    ```bash
    source /opt/ros/humble/setup.bash
-   cd ros2_final_package
+   cd industrial_robotics_simulation_platform
    colcon build --symlink-install
    source install/setup.bash
    ```


### PR DESCRIPTION
## Summary
- update README instructions to reference correct repo directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_6844643e9e0083319b474ce5ccb9f6f2