### PR TITLE
Handle error action via config

### DIFF
--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -184,7 +184,7 @@ class EnvironmentConfiguratorNode(Node):
                     ]
             
             # Handle error simulation
-            if 'trigger_error' in config_data:
+            if config_data.get('action') == 'trigger_error':
                 error_type = config_data.get('type', 'generic')
                 self.simulate_error(error_type)
         


### PR DESCRIPTION
## Summary
- update `config_callback` to parse `action` for error triggers

## Testing
- `python -m py_compile src/simulation_tools/simulation_tools/environment_configurator_node.py`
- `pytest -q` *(fails: ModuleNotFoundError: ament_flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6844646545988331b256f4eeead5dabc