### PR TITLE
Add basic ROS2 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+install/
+log/
+*.pyc
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore build outputs, logs, and Python bytecode

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError for `ament_*` packages)*

------
https://chatgpt.com/codex/tasks/task_e_6844647b8d188331a87924998d9c2ec1