### PR TITLE
Add configurable Werkzeug usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
    ```bash
    ros2 launch simulation_tools integrated_system_launch.py
    ```
+   By default the web interface expects a production WSGI server (e.g. Gunicorn).
+   To use the built-in Werkzeug server for development, pass `use_werkzeug:=true`:
+   ```bash
+   ros2 launch simulation_tools integrated_system_launch.py use_werkzeug:=true
+   ```
 
 3. **Access the Web Interface**
    ```

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -235,6 +235,9 @@ To start the complete system:
 source /opt/ros/humble/setup.bash
 source install/setup.bash
 ros2 launch simulation_tools integrated_system_launch.py
+
+# Use the built-in Werkzeug server (development only)
+# ros2 launch simulation_tools integrated_system_launch.py use_werkzeug:=true
 ```
 
 ### Accessing the Web Interface

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -16,6 +16,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
+    use_werkzeug = LaunchConfiguration('use_werkzeug', default='false')
     
     # Create launch configuration arguments
     launch_args = [
@@ -39,6 +40,10 @@ def generate_launch_description():
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
+        DeclareLaunchArgument(
+            'use_werkzeug',
+            default_value='false',
+            description='Run Flask app with built-in Werkzeug server'),
     ]
     
     # Create data directory
@@ -121,7 +126,8 @@ def generate_launch_description():
                 'port': 8080,
                 'host': '0.0.0.0',
                 'config_dir': config_dir,
-                'data_dir': data_dir
+                'data_dir': data_dir,
+                'use_werkzeug': use_werkzeug
             }],
             output='screen'
         )


### PR DESCRIPTION
## Summary
- add `use_werkzeug` parameter to `WebInterfaceNode`
- update launch file to expose the parameter
- document running with the built-in Werkzeug server in README and deployment guide

## Testing
- `pytest -q`
- `python -m py_compile src/simulation_tools/simulation_tools/web_interface_node.py`


------
https://chatgpt.com/codex/tasks/task_e_68446eff0d248331a4f347f890306453