### PR TITLE
Expose allow_unsafe_werkzeug parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
    http://localhost:8080
    ```
 
+### Web Interface Configuration
+
+The web server uses Flask's development server via `socketio.run`. By default, the
+server refuses to start if Werkzeug is detected in a production environment. You
+can override this for development by enabling the `allow_unsafe_werkzeug`
+parameter:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=true
+```
+
 ## Documentation
 
 For complete details, please refer to the included `industrial_deployment_guide.md` which provides comprehensive instructions for:

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -16,6 +16,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
+    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
     
     # Create launch configuration arguments
     launch_args = [
@@ -39,6 +40,10 @@ def generate_launch_description():
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
+        DeclareLaunchArgument(
+            'allow_unsafe_werkzeug',
+            default_value='false',
+            description='Allow running the web server using Werkzeug in unsafe mode'),
     ]
     
     # Create data directory
@@ -121,7 +126,8 @@ def generate_launch_description():
                 'port': 8080,
                 'host': '0.0.0.0',
                 'config_dir': config_dir,
-                'data_dir': data_dir
+                'data_dir': data_dir,
+                'allow_unsafe_werkzeug': allow_unsafe_werkzeug,
             }],
             output='screen'
         )

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -16,6 +16,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
+    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
     
     # Create default data directory (using the default value, not the LaunchConfiguration)
     default_data_dir = '/tmp/simulation_data'
@@ -43,6 +44,10 @@ def generate_launch_description():
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
+        DeclareLaunchArgument(
+            'allow_unsafe_werkzeug',
+            default_value='false',
+            description='Allow running the web server using Werkzeug in unsafe mode'),
     ]
     
     # Define nodes to launch
@@ -97,7 +102,8 @@ def generate_launch_description():
                 'port': 8080,
                 'host': '0.0.0.0',
                 'config_dir': config_dir,
-                'data_dir': data_dir
+                'data_dir': data_dir,
+                'allow_unsafe_werkzeug': allow_unsafe_werkzeug,
             }],
             output='screen'
         )

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -31,6 +31,7 @@ class WebInterfaceNode(Node):
             'host': '0.0.0.0',
             'config_dir': '',
             'data_dir': '',
+            'allow_unsafe_werkzeug': False,
         }
         self.declare_parameters('', param_defaults)
         
@@ -39,6 +40,7 @@ class WebInterfaceNode(Node):
         self.host = self.get_parameter('host').value
         self.config_dir = self.get_parameter('config_dir').value
         self.data_dir = self.get_parameter('data_dir').value
+        self.allow_unsafe_werkzeug = self.get_parameter('allow_unsafe_werkzeug').value
         
         # Create data directory if it doesn't exist
         if self.data_dir and not os.path.exists(self.data_dir):
@@ -342,7 +344,14 @@ class WebInterfaceNode(Node):
             })
     
     def run_server(self):
-        self.socketio.run(self.app, host=self.host, port=self.port, debug=False, use_reloader=False, allow_unsafe_werkzeug=True)
+        self.socketio.run(
+            self.app,
+            host=self.host,
+            port=self.port,
+            debug=False,
+            use_reloader=False,
+            allow_unsafe_werkzeug=self.allow_unsafe_werkzeug,
+        )
 
 def main(args=None):
     rclpy.init(args=args)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -54,3 +54,9 @@ def test_safety_monitor_node_defaults():
     assert node.get_parameter('safety_rules_file').value == 'safety_rules.yaml'
     assert node.get_parameter('emergency_stop_enabled').value is True
     assert node.get_parameter('collision_detection_enabled').value is True
+
+
+def test_web_interface_node_defaults():
+    from simulation_tools.web_interface_node import WebInterfaceNode
+    node = _init_node(WebInterfaceNode)
+    assert node.get_parameter('allow_unsafe_werkzeug').value is False


### PR DESCRIPTION
## Summary
- add `allow_unsafe_werkzeug` parameter to `WebInterfaceNode`
- propagate the parameter via launch files
- document how to enable it in README
- test for new default value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844789368108331aa26bd55b0f1706d