### PR TITLE
Enable optional robot, Gazebo and MoveIt launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
    ros2 launch simulation_tools integrated_system_launch.py
    ```
 
+### Example Commands
+Run the UR5 with MoveIt enabled:
+```bash
+ros2 launch simulation_tools integrated_system_launch.py \
+  use_delta_robot:=false use_ur5_robot:=true use_moveit:=true
+```
+
+Launch the Delta robot inside Gazebo:
+```bash
+ros2 launch simulation_tools integrated_system_launch.py use_gazebo:=true
+```
+
 3. **Access the Web Interface**
    ```
    http://localhost:8080


### PR DESCRIPTION
## Summary
- conditionally include delta and UR5 robot description launch files
- allow optional Gazebo and MoveIt launches
- document example usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447f4bf29c83319383bc65627a82af