### PR TITLE
Add launch file tests

### DIFF
--- a/tests/test_launch_files.py
+++ b/tests/test_launch_files.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure packages under src/ are importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'src'))
+
+launch = pytest.importorskip('launch')
+launch_ros = pytest.importorskip('launch_ros')
+
+
+def _collect_node_names(description):
+    names = []
+    for action in description.entities:
+        name = getattr(action, 'name', None)
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def test_integrated_system_launch_realsense_disabled(monkeypatch):
+    from simulation_tools.launch import integrated_system_launch
+
+    monkeypatch.setattr(integrated_system_launch, 'LaunchConfiguration', lambda *args, **kwargs: 'false')
+    ld = integrated_system_launch.generate_launch_description()
+    names = _collect_node_names(ld)
+    assert 'realsense2_camera' not in names
+    assert 'camera_simulator' in names
+
+
+def test_integrated_system_launch_realsense_enabled(monkeypatch):
+    from simulation_tools.launch import integrated_system_launch
+
+    monkeypatch.setattr(integrated_system_launch, 'LaunchConfiguration', lambda *args, **kwargs: 'true')
+    ld = integrated_system_launch.generate_launch_description()
+    names = _collect_node_names(ld)
+    assert 'realsense2_camera' in names
+    assert 'camera_simulator' not in names
+
+
+def test_realsense_hybrid_launch_has_realsense():
+    from simulation_tools.launch import realsense_hybrid_launch
+
+    ld = realsense_hybrid_launch.generate_launch_description()
+    names = _collect_node_names(ld)
+    assert 'realsense2_camera' in names


### PR DESCRIPTION
## Summary
- add launch tests for RealSense options
- verify RealSense nodes exist or not depending on arguments

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68447f7573b48331b1e85e0615ee8daf