### PR TITLE
Add UR5 mesh asset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,18 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
    - Safety zone enforcement
 
 6. **Demonstration Tools**
-   - Scenario recording and playback
-   - Error simulation for robustness testing
-   - Data export for analysis and reporting
+  - Scenario recording and playback
+  - Error simulation for robustness testing
+  - Data export for analysis and reporting
+
+## UR5 Mesh Assets
+
+The `ur5_robot_description` package references UR5 mesh files which are not
+included in this repository. Before building the workspace you can either
+download the meshes from the
+[Universal Robots description package](https://github.com/ros-industrial/universal_robot)
+and place them in `src/ur5_robot_description/meshes`, or remove the `meshes`
+directory from `src/ur5_robot_description/CMakeLists.txt`.
 
 ## Getting Started
 

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -107,6 +107,15 @@ pip3 install flask flask-socketio rclpy numpy opencv-python pyyaml matplotlib
 pip3 install asyncua paho-mqtt  # For industrial protocol support
 ```
 
+### UR5 Mesh Assets
+
+The `ur5_robot_description` package provided in this repository installs a
+`meshes` directory, but the actual UR5 mesh files are not included.
+Before building the workspace either download the meshes from the
+[Universal Robots description package](https://github.com/ros-industrial/universal_robot)
+and place them in `src/ur5_robot_description/meshes`, or remove the `meshes`
+entry from `src/ur5_robot_description/CMakeLists.txt`.
+
 ### Building the Workspace
 
 1. Clone the repository:


### PR DESCRIPTION
## Summary
- add UR5 mesh asset notes to README before build steps
- add UR5 mesh asset notes to industrial deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448b9999388331a092718814411ba0