### PR TITLE
Fix UR5 description install

### DIFF
--- a/src/ur5_robot_description/CMakeLists.txt
+++ b/src/ur5_robot_description/CMakeLists.txt
@@ -5,9 +5,15 @@ find_package(ament_cmake REQUIRED)
 
 install(DIRECTORY
   urdf
-  meshes
   launch
   DESTINATION share/${PROJECT_NAME}
 )
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/meshes")
+  install(DIRECTORY
+    meshes
+    DESTINATION share/${PROJECT_NAME}
+  )
+endif()
 
 ament_package()


### PR DESCRIPTION
## Summary
- fix UR5 robot description CMake install directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449a844e848331ae93aee34bca734a