### PR TITLE
Fix wget download command

### DIFF
--- a/src/apm_core/scripts/convert_model_to_onnx.py
+++ b/src/apm_core/scripts/convert_model_to_onnx.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import subprocess
 import argparse
 import tensorflow as tf
 import tf2onnx
@@ -33,7 +34,17 @@ def download_tf_model(model_name, output_dir):
     
     # Download the model file if it doesn't exist
     if not os.path.exists(model_file):
-        os.system(f"wget -O {model_file} {model_url}")
+        try:
+            subprocess.run([
+                "wget",
+                "-O",
+                model_file,
+                model_url,
+            ], check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"Failed to download model from {model_url}"
+            ) from exc
     
     # Extract the model if the directory doesn't exist
     extract_dir = os.path.join(output_dir, model_name)


### PR DESCRIPTION
## Summary
- use `subprocess.run` with error handling when downloading models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449a9ac3e4833199af4ad1cd356705