### PR TITLE
Fix parameter declarations to avoid TypeError

### DIFF
--- a/src/simulation_tools/simulation_tools/camera_simulator_node.py
+++ b/src/simulation_tools/simulation_tools/camera_simulator_node.py
@@ -31,7 +31,7 @@ class CameraSimulatorNode(Node):
             'simulate_lighting': True,
             'simulate_occlusion': False,
         }
-        self.declare_parameters('', param_defaults)
+        self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         
         # Get parameters
         self.simulation_mode = self.get_parameter('simulation_mode').value

--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -23,7 +23,7 @@ class EnvironmentConfiguratorNode(Node):
             'record_metrics': True,
             'error_simulation_rate': 0.0,
         }
-        self.declare_parameters('', param_defaults)
+        self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
 
         # Get parameters
         self.config_dir = self.get_parameter('config_dir').value

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -34,7 +34,7 @@ class WebInterfaceNode(Node):
             'data_dir': '',
             'allow_unsafe_werkzeug': False,
         }
-        self.declare_parameters('', param_defaults)
+        self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         
         # Get parameters
         self.port = self.get_parameter('port').value


### PR DESCRIPTION
## Summary
- fix parameter declaration patterns in ROS2 nodes
- keep tests working

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449ec8f3988331834ac3d1385bd1f1