### PR TITLE
Add opcua_port launch argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ directory from `src/ur5_robot_description/CMakeLists.txt`.
    ```
    The `scenario` argument defaults to `default`.
 
+   To change the OPC UA server port, pass the `opcua_port` argument:
+   ```bash
+   ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+   ```
+   This argument is also supported by `realsense_hybrid_launch.py`.
+
 3. **Access the Web Interface**
    ```
    http://localhost:8080

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -234,6 +234,13 @@ mqtt:
 hybrid_mode: false
 ```
 
+The OPC UA server port can also be overridden at launch using the `opcua_port`
+argument. For example:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+```
+
 ## Operation
 
 ### Starting the System

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -22,6 +22,7 @@ def generate_launch_description():
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
+    opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
     # Create launch configuration arguments
     launch_args = [
@@ -53,6 +54,10 @@ def generate_launch_description():
             'allow_unsafe_werkzeug',
             default_value='false',
             description='Allow running the web server using Werkzeug in unsafe mode'),
+        DeclareLaunchArgument(
+            'opcua_port',
+            default_value='4840',
+            description='Port for the OPC UA server'),
     ]
     
     # Create data directory during launch execution
@@ -181,7 +186,7 @@ def generate_launch_description():
             parameters=[{
                 'config_dir': config_dir,
                 'opcua_enabled': True,
-                'opcua_endpoint': 'opc.tcp://0.0.0.0:4840/freeopcua/server/',
+                'opcua_endpoint': ['opc.tcp://0.0.0.0:', opcua_port, '/freeopcua/server/'],
                 'mqtt_enabled': True,
                 'mqtt_broker': 'localhost',
                 'mqtt_port': 1883,

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -17,6 +17,7 @@ def generate_launch_description():
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
+    opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
     # Create default data directory (using the default value, not the LaunchConfiguration)
     default_data_dir = '/tmp/simulation_data'
@@ -48,6 +49,10 @@ def generate_launch_description():
             'allow_unsafe_werkzeug',
             default_value='false',
             description='Allow running the web server using Werkzeug in unsafe mode'),
+        DeclareLaunchArgument(
+            'opcua_port',
+            default_value='4840',
+            description='Port for the OPC UA server'),
     ]
     
     # Define nodes to launch
@@ -134,7 +139,7 @@ def generate_launch_description():
             parameters=[{
                 'config_dir': config_dir,
                 'opcua_enabled': True,
-                'opcua_endpoint': 'opc.tcp://0.0.0.0:4840/freeopcua/server/',
+                'opcua_endpoint': ['opc.tcp://0.0.0.0:', opcua_port, '/freeopcua/server/'],
                 'mqtt_enabled': True,
                 'mqtt_broker': 'localhost',
                 'mqtt_port': 1883,


### PR DESCRIPTION
## Summary
- add `opcua_port` launch argument to integrated and realsense hybrid launches
- generate OPC UA endpoint using this port
- document the new argument in the README and deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c28774f483319b474e11b502c10a