### PR TITLE
Add setup.cfg for advanced_perception

### DIFF
--- a/src/advanced_perception/setup.cfg
+++ b/src/advanced_perception/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/advanced_perception
+[install]
+install_scripts=$base/lib/advanced_perception


### PR DESCRIPTION
## Summary
- add `setup.cfg` to advanced_perception

## Testing
- `colcon build --symlink-install` *(fails: could not find `ament_cmake`)*
- `ros2 pkg executables advanced_perception` *(fails: `ros2` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d3969e6c833183c7d6bce1cb8788