### PR TITLE
Enable web interface by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ directory from `src/ur5_robot_description/CMakeLists.txt`.
 
 ### Web Interface Configuration
 
-The web server uses Flask's development server via `socketio.run`. By default, the
-server refuses to start if Werkzeug is detected in a production environment. You
-can override this for development by enabling the `allow_unsafe_werkzeug`
-parameter:
+The web server uses Flask's development server via `socketio.run`. By default,
+the system allows Werkzeug to run even if a production environment is
+detected. You can disable this override by setting the `allow_unsafe_werkzeug`
+parameter to `false`:
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=true
+ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=false
 ```
 
 ## Documentation

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
-    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
+    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
     # Create launch configuration arguments
@@ -52,7 +52,7 @@ def generate_launch_description():
             description='Directory for storing data and exports'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',
-            default_value='false',
+            default_value='true',
             description='Allow running the web server using Werkzeug in unsafe mode'),
         DeclareLaunchArgument(
             'opcua_port',

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -16,7 +16,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
-    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='false')
+    allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
     # Create default data directory (using the default value, not the LaunchConfiguration)
@@ -47,7 +47,7 @@ def generate_launch_description():
             description='Directory for storing data and exports'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',
-            default_value='false',
+            default_value='true',
             description='Allow running the web server using Werkzeug in unsafe mode'),
         DeclareLaunchArgument(
             'opcua_port',

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -32,7 +32,7 @@ class WebInterfaceNode(Node):
             'host': '0.0.0.0',
             'config_dir': '',
             'data_dir': '',
-            'allow_unsafe_werkzeug': False,
+            'allow_unsafe_werkzeug': True,
         }
         self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -60,4 +60,4 @@ def test_safety_monitor_node_defaults():
 def test_web_interface_node_defaults():
     from simulation_tools.web_interface_node import WebInterfaceNode
     node = _init_node(WebInterfaceNode)
-    assert node.get_parameter('allow_unsafe_werkzeug').value is False
+    assert node.get_parameter('allow_unsafe_werkzeug').value is True


### PR DESCRIPTION
## Summary
- set `allow_unsafe_werkzeug` parameter default to `True`
- update launch files to reflect new default
- document new behavior in README
- adjust node tests for the new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dcc67710833187b2db0a8fb7f016