### PR TITLE
Fix repo name in industrial deployment guide

### DIFF
--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -120,8 +120,8 @@ entry from `src/ur5_robot_description/CMakeLists.txt`.
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/your-organization/industrial-robotics-simulation.git
-cd industrial-robotics-simulation
+git clone https://github.com/your-organization/industrial_robotics_simulation_platform.git
+cd industrial_robotics_simulation_platform
 ```
 
 2. Build the workspace:


### PR DESCRIPTION
## Summary
- update the cloning instructions in `industrial_deployment_guide.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845de928b1c8331bd7c5438216c1cc0