### PR TITLE
Add apm_msgs import skip

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / 'src'))
 
 rclpy = pytest.importorskip('rclpy')
+apm_msgs = pytest.importorskip("apm_msgs")
 
 
 def _init_node(node_cls):


### PR DESCRIPTION
## Summary
- handle missing `apm_msgs` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ee46cd188331bddc104b779f3806