### PR TITLE
Update OPC UA defaults and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ directory from `src/ur5_robot_description/CMakeLists.txt`.
    ```
    This argument is also supported by `realsense_hybrid_launch.py`.
 
+   The OPC UA server is configured with minimal security and, by default, only
+   listens on `127.0.0.1`. If you need to allow remote connections, override the
+   `opcua_endpoint` parameter with a host accessible on your network, e.g.:
+   ```bash
+   ros2 launch simulation_tools integrated_system_launch.py \
+       opcua_endpoint:=opc.tcp://0.0.0.0:4840/freeopcua/server/
+   ```
+
 3. **Access the Web Interface**
    ```
    http://localhost:8080

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -226,7 +226,7 @@ Example industrial protocol configuration:
 ```yaml
 opcua:
   enabled: true
-  endpoint: opc.tcp://0.0.0.0:4840/freeopcua/server/
+  endpoint: opc.tcp://127.0.0.1:4840/freeopcua/server/
 mqtt:
   enabled: true
   broker: localhost
@@ -240,6 +240,11 @@ argument. For example:
 ```bash
 ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
 ```
+
+The OPC UA server runs with minimal security configuration and listens only on
+`127.0.0.1` by default. To allow remote clients, override the `opcua_endpoint`
+parameter with an address accessible on your network, such as
+`opc.tcp://0.0.0.0:4840/freeopcua/server/`.
 
 ## Operation
 

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -186,7 +186,7 @@ def generate_launch_description():
             parameters=[{
                 'config_dir': config_dir,
                 'opcua_enabled': True,
-                'opcua_endpoint': ['opc.tcp://0.0.0.0:', opcua_port, '/freeopcua/server/'],
+                'opcua_endpoint': ['opc.tcp://127.0.0.1:', opcua_port, '/freeopcua/server/'],
                 'mqtt_enabled': True,
                 'mqtt_broker': 'localhost',
                 'mqtt_port': 1883,

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -139,7 +139,7 @@ def generate_launch_description():
             parameters=[{
                 'config_dir': config_dir,
                 'opcua_enabled': True,
-                'opcua_endpoint': ['opc.tcp://0.0.0.0:', opcua_port, '/freeopcua/server/'],
+                'opcua_endpoint': ['opc.tcp://127.0.0.1:', opcua_port, '/freeopcua/server/'],
                 'mqtt_enabled': True,
                 'mqtt_broker': 'localhost',
                 'mqtt_port': 1883,

--- a/src/simulation_tools/simulation_tools/industrial_protocol_bridge_node.py
+++ b/src/simulation_tools/simulation_tools/industrial_protocol_bridge_node.py
@@ -19,7 +19,7 @@ class IndustrialProtocolBridgeNode(Node):
         # Declare parameters
         self.declare_parameter('config_dir', '')
         self.declare_parameter('opcua_enabled', True)
-        self.declare_parameter('opcua_endpoint', 'opc.tcp://0.0.0.0:4840/freeopcua/server/')
+        self.declare_parameter('opcua_endpoint', 'opc.tcp://127.0.0.1:4840/freeopcua/server/')
         self.declare_parameter('mqtt_enabled', True)
         self.declare_parameter('mqtt_broker', 'localhost')
         self.declare_parameter('mqtt_port', 1883)


### PR DESCRIPTION
## Summary
- restrict OPC UA endpoint to localhost by default
- update launch files with localhost endpoint
- document default security and how to expose the server

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement rclpy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ee7c0de483318f1587e070722b19