### PR TITLE
Document MQTT broker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ parameter to `false`:
 ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=false
 ```
 
+### MQTT Broker Configuration
+
+The system's example launch files assume a local MQTT broker running on
+`localhost:1883`. This broker is started without any authentication or
+encryption, which is convenient for testing but **not** recommended for
+production deployments.
+
+For a secure setup, bind the broker to an appropriate network interface and
+enable credentials or TLS. Update the `mqtt_broker` and `mqtt_port` arguments in
+the launch file or your YAML configuration:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py \
+    mqtt_broker:=your.broker.host mqtt_port:=8883
+```
+
+Consult your broker's documentation for enabling username/password files or SSL
+certificates before exposing the service to other machines.
+
 ## Documentation
 
 For complete details, please refer to the included `industrial_deployment_guide.md` which provides comprehensive instructions for:

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -241,6 +241,24 @@ argument. For example:
 ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
 ```
 
+#### MQTT Broker Configuration
+
+By default the MQTT broker expected by the system runs on `localhost:1883`
+with no authentication enabled. This unsecured setup simplifies evaluation but
+is not appropriate for production deployments.
+
+Bind your broker to a secure network interface and configure credentials or
+TLS encryption. Adjust the `mqtt_broker` and `mqtt_port` parameters in your
+configuration or on the command line:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py \
+    mqtt_broker:=your.broker.host mqtt_port:=8883
+```
+
+Refer to your broker's documentation (e.g., Mosquitto) for enabling
+username/password files and SSL certificates.
+
 ## Operation
 
 ### Starting the System


### PR DESCRIPTION
## Summary
- add MQTT broker configuration section in README
- document production MQTT settings in industrial deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ee83b8208331afe2fe7b6783f00b