### PR TITLE
Add Mosquitto security examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,22 @@ The mesh resources are required for accurate visualization in both cases.
 
    To change the OPC UA server port, pass the `opcua_port` argument:
    ```bash
-   ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+  ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+  ```
+  This argument is also supported by `realsense_hybrid_launch.py`.
+
+   To secure MQTT communication, configure authentication and TLS in your
+   Mosquitto broker. Set the `password_file` option and create a dedicated
+   listener for TLS traffic:
    ```
-   This argument is also supported by `realsense_hybrid_launch.py`.
+   listener 8883
+   password_file /etc/mosquitto/passwd
+   cafile /etc/mosquitto/ca.crt
+   certfile /etc/mosquitto/server.crt
+   keyfile /etc/mosquitto/server.key
+   allow_anonymous false
+   ```
+   Refer to the [Mosquitto security documentation](https://mosquitto.org/man/mosquitto-conf-5.html) for details.
 
    The OPC UA server is configured with minimal security and, by default, only
    listens on `127.0.0.1`. If you need to allow remote connections, override the

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -250,6 +250,18 @@ The OPC UA server runs with minimal security configuration and listens only on
 parameter with an address accessible on your network, such as
 `opc.tcp://0.0.0.0:4840/freeopcua/server/`.
 
+For MQTT, you can enable authentication and TLS in your Mosquitto broker by
+specifying a `password_file` and a secure listener. Example `mosquitto.conf`:
+```
+listener 8883
+password_file /etc/mosquitto/passwd
+cafile /etc/mosquitto/ca.crt
+certfile /etc/mosquitto/server.crt
+keyfile /etc/mosquitto/server.key
+allow_anonymous false
+```
+See the [Mosquitto documentation](https://mosquitto.org/man/mosquitto-conf-5.html) for a full explanation of these options.
+
 ## Operation
 
 ### Starting the System


### PR DESCRIPTION
## Summary
- document Mosquitto authentication and TLS options in README
- add Mosquitto security snippet to deployment guide

## Testing
- `pip install -r requirements.txt` *(fails: rclpy not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845f206d7cc8331bac025b7f37e9bb7