### PR TITLE
Add JPEG quality parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ parameter to `false`:
 ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=false
 ```
 
+Both `web_interface_node` and `visualization_server_node` support a `jpeg_quality`
+parameter to control JPEG compression (0-100). The default value is `75`.
+
 ## Documentation
 
 For complete details, please refer to the included `industrial_deployment_guide.md` which provides comprehensive instructions for:

--- a/src/simulation_tools/simulation_tools/visualization_server_node.py
+++ b/src/simulation_tools/simulation_tools/visualization_server_node.py
@@ -20,12 +20,14 @@ class VisualizationServerNode(Node):
         self.declare_parameter('export_enabled', True)
         self.declare_parameter('export_interval', 60.0)
         self.declare_parameter('visualization_rate', 10.0)
+        self.declare_parameter('jpeg_quality', 75)
         
         # Get parameters
         self.data_dir = self.get_parameter('data_dir').value
         self.export_enabled = self.get_parameter('export_enabled').value
         self.export_interval = self.get_parameter('export_interval').value
         self.visualization_rate = self.get_parameter('visualization_rate').value
+        self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
         
         # Create data directory if it doesn't exist
         if self.data_dir and not os.path.exists(self.data_dir):
@@ -147,7 +149,16 @@ class VisualizationServerNode(Node):
             
             # Save combined view
             if self.data_dir:
-                cv2.imwrite(os.path.join(self.data_dir, 'combined_view.jpg'), combined_view)
+                success, buffer = cv2.imencode(
+                    '.jpg',
+                    combined_view,
+                    [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+                )
+                if success:
+                    with open(
+                        os.path.join(self.data_dir, 'combined_view.jpg'), 'wb'
+                    ) as f:
+                        f.write(buffer.tobytes())
         
         # Create metrics visualization
         metrics_view = self.create_metrics_visualization()
@@ -160,7 +171,16 @@ class VisualizationServerNode(Node):
             
             # Save metrics view
             if self.data_dir:
-                cv2.imwrite(os.path.join(self.data_dir, 'metrics_view.jpg'), metrics_view)
+                success, buffer = cv2.imencode(
+                    '.jpg',
+                    metrics_view,
+                    [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+                )
+                if success:
+                    with open(
+                        os.path.join(self.data_dir, 'metrics_view.jpg'), 'wb'
+                    ) as f:
+                        f.write(buffer.tobytes())
     
     def export_callback(self):
         if not self.export_enabled or not self.data_dir:
@@ -179,23 +199,55 @@ class VisualizationServerNode(Node):
         
         # Export images
         if self.rgb_image is not None:
-            cv2.imwrite(os.path.join(export_path, 'rgb.jpg'), self.rgb_image)
+            success, buffer = cv2.imencode(
+                '.jpg',
+                self.rgb_image,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+            if success:
+                with open(os.path.join(export_path, 'rgb.jpg'), 'wb') as f:
+                    f.write(buffer.tobytes())
         
         if self.depth_image is not None:
             # Normalize depth for visualization
             depth_normalized = cv2.normalize(self.depth_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U)
             depth_colormap = cv2.applyColorMap(depth_normalized, cv2.COLORMAP_JET)
-            cv2.imwrite(os.path.join(export_path, 'depth.jpg'), depth_colormap)
+            success, buffer = cv2.imencode(
+                '.jpg',
+                depth_colormap,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+            if success:
+                with open(os.path.join(export_path, 'depth.jpg'), 'wb') as f:
+                    f.write(buffer.tobytes())
         
         # Export combined view
         combined_view = self.create_combined_view()
         if combined_view is not None:
-            cv2.imwrite(os.path.join(export_path, 'combined_view.jpg'), combined_view)
+            success, buffer = cv2.imencode(
+                '.jpg',
+                combined_view,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+            if success:
+                with open(
+                    os.path.join(export_path, 'combined_view.jpg'), 'wb'
+                ) as f:
+                    f.write(buffer.tobytes())
         
         # Export metrics visualization
         metrics_view = self.create_metrics_visualization()
         if metrics_view is not None:
-            cv2.imwrite(os.path.join(export_path, 'metrics_view.jpg'), metrics_view)
+            success, buffer = cv2.imencode(
+                '.jpg',
+                metrics_view,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+            if success:
+                with open(
+                    os.path.join(export_path, 'metrics_view.jpg'), 'wb'
+                ) as f:
+                    f.write(buffer.tobytes())
         
         # Export metrics data
         if self.metrics:

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -35,6 +35,7 @@ class WebInterfaceNode(Node):
             'data_dir': '',
             'allow_unsafe_werkzeug': True,
             'log_db_path': '',
+            'jpeg_quality': 75,
         }
         self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         
@@ -45,6 +46,7 @@ class WebInterfaceNode(Node):
         self.data_dir = self.get_parameter('data_dir').value
         self.allow_unsafe_werkzeug = self.get_parameter('allow_unsafe_werkzeug').value
         self.log_db_path = self.get_parameter('log_db_path').value
+        self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
 
         if not self.log_db_path:
             if self.data_dir:
@@ -147,13 +149,19 @@ class WebInterfaceNode(Node):
         try:
             self.latest_rgb_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
             
+            success, buffer = cv2.imencode(
+                '.jpg',
+                self.latest_rgb_image,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+
             # Optionally save image to file
-            if self.data_dir:
+            if self.data_dir and success:
                 image_path = os.path.join(self.data_dir, 'latest_rgb.jpg')
-                cv2.imwrite(image_path, self.latest_rgb_image)
+                with open(image_path, 'wb') as f:
+                    f.write(buffer.tobytes())
 
             # Encode image and emit directly to clients
-            success, buffer = cv2.imencode('.jpg', self.latest_rgb_image)
             if success:
                 b64_data = base64.b64encode(buffer.tobytes()).decode('utf-8')
                 self.socketio.emit('image_data', {'rgb': b64_data})
@@ -168,13 +176,19 @@ class WebInterfaceNode(Node):
             depth_normalized = cv2.normalize(self.latest_depth_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U)
             depth_colormap = cv2.applyColorMap(depth_normalized, cv2.COLORMAP_JET)
             
+            success, buffer = cv2.imencode(
+                '.jpg',
+                depth_colormap,
+                [cv2.IMWRITE_JPEG_QUALITY, self.jpeg_quality],
+            )
+
             # Optionally save image to file
-            if self.data_dir:
+            if self.data_dir and success:
                 image_path = os.path.join(self.data_dir, 'latest_depth.jpg')
-                cv2.imwrite(image_path, depth_colormap)
+                with open(image_path, 'wb') as f:
+                    f.write(buffer.tobytes())
 
             # Encode depth image and emit directly to clients
-            success, buffer = cv2.imencode('.jpg', depth_colormap)
             if success:
                 b64_data = base64.b64encode(buffer.tobytes()).decode('utf-8')
                 self.socketio.emit('image_data', {'depth': b64_data})

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -63,3 +63,14 @@ def test_web_interface_node_defaults():
     node = _init_node(WebInterfaceNode)
     assert node.get_parameter('allow_unsafe_werkzeug').value is True
     assert node.get_parameter('log_db_path').value == ''
+    assert node.get_parameter('jpeg_quality').value == 75
+
+
+def test_visualization_server_node_defaults():
+    from simulation_tools.visualization_server_node import VisualizationServerNode
+    node = _init_node(VisualizationServerNode)
+    assert node.get_parameter('data_dir').value == ''
+    assert node.get_parameter('export_enabled').value is True
+    assert node.get_parameter('export_interval').value == 60.0
+    assert node.get_parameter('visualization_rate').value == 10.0
+    assert node.get_parameter('jpeg_quality').value == 75


### PR DESCRIPTION
## Summary
- add `jpeg_quality` parameter in web interface and visualization server
- encode JPEGs with custom quality for streaming and saving
- document the new parameter in README
- test default values for the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f5d635d88331a6a6c5a5988db309