### PR TITLE
Stream images without saving to disk

### DIFF
--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -21,6 +21,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
+    save_images = LaunchConfiguration('save_images', default='true')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
@@ -50,6 +51,10 @@ def generate_launch_description():
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
+        DeclareLaunchArgument(
+            'save_images',
+            default_value='true',
+            description='Save latest images to disk'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',
             default_value='true',
@@ -155,6 +160,7 @@ def generate_launch_description():
                 'host': '0.0.0.0',
                 'config_dir': config_dir,
                 'data_dir': data_dir,
+                'save_images': save_images,
                 'allow_unsafe_werkzeug': allow_unsafe_werkzeug,
             }],
             output='screen'

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -16,6 +16,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
+    save_images = LaunchConfiguration('save_images', default='true')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
     
@@ -45,6 +46,10 @@ def generate_launch_description():
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
+        DeclareLaunchArgument(
+            'save_images',
+            default_value='true',
+            description='Save latest images to disk'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',
             default_value='true',
@@ -108,6 +113,7 @@ def generate_launch_description():
                 'host': '0.0.0.0',
                 'config_dir': config_dir,
                 'data_dir': data_dir,
+                'save_images': save_images,
                 'allow_unsafe_werkzeug': allow_unsafe_werkzeug,
             }],
             output='screen'

--- a/src/simulation_tools/templates/control.html
+++ b/src/simulation_tools/templates/control.html
@@ -103,6 +103,15 @@
             </div>
             
             <div class="col-md-8">
+                <div class="card mb-3">
+                    <div class="card-header">
+                        <h5 class="card-title">Camera Feed</h5>
+                    </div>
+                    <div class="card-body text-center">
+                        <img id="rgb-image" class="img-fluid mb-2" alt="RGB">
+                        <img id="depth-image" class="img-fluid" alt="Depth">
+                    </div>
+                </div>
                 <div class="card">
                     <div class="card-header">
                         <h5 class="card-title">Workspace Visualization</h5>
@@ -143,6 +152,8 @@
         const placeCustomBtn = document.getElementById('place-custom-btn');
         const commandLog = document.getElementById('command-log');
         const workspaceCanvas = document.getElementById('workspace-canvas');
+        const rgbImage = document.getElementById('rgb-image');
+        const depthImage = document.getElementById('depth-image');
         
         // Canvas context
         const ctx = workspaceCanvas.getContext('2d');
@@ -183,12 +194,22 @@
         socket.on('objects_update', function(data) {
             objects = data.objects;
             objectsCount.textContent = objects.length;
-            
+
             // Update object dropdown
             updateObjectDropdown();
-            
+
             // Draw workspace
             drawWorkspace();
+        });
+
+        // Camera image handler
+        socket.on('image_data', function(data) {
+            if (data.rgb && rgbImage) {
+                rgbImage.src = 'data:image/jpeg;base64,' + data.rgb;
+            }
+            if (data.depth && depthImage) {
+                depthImage.src = 'data:image/jpeg;base64,' + data.depth;
+            }
         });
         
         // Update object dropdown

--- a/src/simulation_tools/templates/dashboard.html
+++ b/src/simulation_tools/templates/dashboard.html
@@ -93,6 +93,15 @@
             </div>
             
             <div class="col-md-8">
+                <div class="card mb-3">
+                    <div class="card-header">
+                        <h5 class="card-title">Camera Feed</h5>
+                    </div>
+                    <div class="card-body text-center">
+                        <img id="rgb-image" class="img-fluid mb-2" alt="RGB">
+                        <img id="depth-image" class="img-fluid" alt="Depth">
+                    </div>
+                </div>
                 <div class="card">
                     <div class="card-header">
                         <h5 class="card-title">Detected Objects</h5>
@@ -122,6 +131,8 @@
         const noObjectsMessage = document.getElementById('no-objects-message');
         const objectsList = document.getElementById('objects-list');
         const refreshBtn = document.getElementById('refresh-btn');
+        const rgbImage = document.getElementById('rgb-image');
+        const depthImage = document.getElementById('depth-image');
         
         // Update last update time
         function updateLastUpdateTime() {
@@ -240,6 +251,16 @@
                     });
                 });
             });
+        });
+
+        // Camera image handler
+        socket.on('image_data', function(data) {
+            if (data.rgb && rgbImage) {
+                rgbImage.src = 'data:image/jpeg;base64,' + data.rgb;
+            }
+            if (data.depth && depthImage) {
+                depthImage.src = 'data:image/jpeg;base64,' + data.depth;
+            }
         });
         
         // Refresh button handler

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -62,4 +62,5 @@ def test_web_interface_node_defaults():
     from simulation_tools.web_interface_node import WebInterfaceNode
     node = _init_node(WebInterfaceNode)
     assert node.get_parameter('allow_unsafe_werkzeug').value is True
+    assert node.get_parameter('save_images').value is True
     assert node.get_parameter('log_db_path').value == ''


### PR DESCRIPTION
## Summary
- add new `save_images` parameter to configure disk saving in `web_interface_node`
- stream base64 JPEG frames over SocketIO and fallback for `/api/image/latest`
- expose new argument to launch files
- update dashboard and control pages to show streamed images
- test coverage for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f5d867e08331b7028e19d563bfc4