### PR TITLE
Fix DetectedObject field references

### DIFF
--- a/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
+++ b/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
@@ -207,11 +207,11 @@ class FMMMoveitInterfaceNode(Node):
                 target_object = self.detected_objects[object_id]
             
             # Transform object pose to planning frame if needed
-            object_pose = target_object.pose.pose
-            if target_object.pose.header.frame_id != self.base_link:
+            object_pose = target_object.pose
+            if target_object.header.frame_id != self.base_link:
                 transform = self.tf_buffer.lookup_transform(
                     self.base_link,
-                    target_object.pose.header.frame_id,
+                    target_object.header.frame_id,
                     rclpy.time.Time()
                 )
                 object_pose = do_transform_pose(object_pose, transform)

--- a/src/fmm_core/fmm_core/pick_and_place_node.py
+++ b/src/fmm_core/fmm_core/pick_and_place_node.py
@@ -149,11 +149,11 @@ class PickAndPlaceNode(Node):
         """
         try:
             # Transform object pose to planning frame if needed
-            object_pose = obj.pose.pose
-            if obj.pose.header.frame_id != self.base_link:
+            object_pose = obj.pose
+            if obj.header.frame_id != self.base_link:
                 transform = self.tf_buffer.lookup_transform(
                     self.base_link,
-                    obj.pose.header.frame_id,
+                    obj.header.frame_id,
                     rclpy.time.Time()
                 )
                 object_pose = do_transform_pose(object_pose, transform)
@@ -167,7 +167,7 @@ class PickAndPlaceNode(Node):
             self.scene.add_box(
                 f"object_{obj.id}",
                 pose_stamped,
-                size=(obj.size.x, obj.size.y, obj.size.z)
+                size=(obj.dimensions.x, obj.dimensions.y, obj.dimensions.z)
             )
             
             self.get_logger().debug(f"Added object {obj.id} to planning scene")
@@ -289,11 +289,11 @@ class PickAndPlaceNode(Node):
                 target_object = self.detected_objects[object_id]
             
             # Transform object pose to planning frame if needed
-            object_pose = target_object.pose.pose
-            if target_object.pose.header.frame_id != self.base_link:
+            object_pose = target_object.pose
+            if target_object.header.frame_id != self.base_link:
                 transform = self.tf_buffer.lookup_transform(
                     self.base_link,
-                    target_object.pose.header.frame_id,
+                    target_object.header.frame_id,
                     rclpy.time.Time()
                 )
                 object_pose = do_transform_pose(object_pose, transform)

--- a/src/fmm_core/fmm_core/planning_scene_updater_node.py
+++ b/src/fmm_core/fmm_core/planning_scene_updater_node.py
@@ -96,15 +96,15 @@ class PlanningSceneUpdaterNode(Node):
                 
                 try:
                     # Transform pose to planning frame if needed
-                    if obj.pose.header.frame_id != self.world_frame:
+                    if obj.header.frame_id != self.world_frame:
                         transform = self.tf_buffer.lookup_transform(
                             self.world_frame,
-                            obj.pose.header.frame_id,
+                            obj.header.frame_id,
                             rclpy.time.Time()
                         )
-                        transformed_pose = do_transform_pose(obj.pose.pose, transform)
+                        transformed_pose = do_transform_pose(obj.pose, transform)
                     else:
-                        transformed_pose = obj.pose.pose
+                        transformed_pose = obj.pose
                     
                     # Create collision object
                     co = CollisionObject()
@@ -113,34 +113,14 @@ class PlanningSceneUpdaterNode(Node):
                     co.id = f"object_{obj.id}"
                     co.operation = CollisionObject.ADD
                     
-                    # Create primitive based on object type
+                    # Create a box primitive using the object's dimensions
                     primitive = SolidPrimitive()
-                    if obj.shape == "box":
-                        primitive.type = SolidPrimitive.BOX
-                        primitive.dimensions = [
-                            obj.dimensions.x + self.object_padding,
-                            obj.dimensions.y + self.object_padding,
-                            obj.dimensions.z + self.object_padding
-                        ]
-                    elif obj.shape == "cylinder":
-                        primitive.type = SolidPrimitive.CYLINDER
-                        primitive.dimensions = [
-                            obj.dimensions.z + self.object_padding,  # height
-                            obj.dimensions.x / 2.0 + self.object_padding  # radius
-                        ]
-                    elif obj.shape == "sphere":
-                        primitive.type = SolidPrimitive.SPHERE
-                        primitive.dimensions = [
-                            obj.dimensions.x / 2.0 + self.object_padding  # radius
-                        ]
-                    else:
-                        # Default to box
-                        primitive.type = SolidPrimitive.BOX
-                        primitive.dimensions = [
-                            obj.dimensions.x + self.object_padding,
-                            obj.dimensions.y + self.object_padding,
-                            obj.dimensions.z + self.object_padding
-                        ]
+                    primitive.type = SolidPrimitive.BOX
+                    primitive.dimensions = [
+                        obj.dimensions.x + self.object_padding,
+                        obj.dimensions.y + self.object_padding,
+                        obj.dimensions.z + self.object_padding,
+                    ]
                     
                     co.primitives.append(primitive)
                     co.primitive_poses.append(transformed_pose)


### PR DESCRIPTION
## Summary
- use DetectedObject pose field directly in pick and place node
- fix MoveIt interface node to use DetectedObject.pose and header
- clean up planning scene updater to drop unsupported fields and use dimensions
- run unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cff3242883318ebfd859ae461dc8