### PR TITLE
Add ActionLogger closing and web interface cleanup

### DIFF
--- a/src/simulation_tools/simulation_tools/action_logger.py
+++ b/src/simulation_tools/simulation_tools/action_logger.py
@@ -34,3 +34,17 @@ class ActionLogger:
                 (timestamp, action, detail_str)
             )
             self._conn.commit()
+
+    def close(self):
+        """Close the underlying SQLite connection."""
+        if self._conn is not None:
+            with self._lock:
+                self._conn.close()
+                self._conn = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -50,6 +50,10 @@ class WebInterfaceNode(Node):
         self.log_db_path = self.get_parameter('log_db_path').value
         self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
 
+        # Create data directory if it doesn't exist before using it
+        if self.data_dir and not os.path.exists(self.data_dir):
+            os.makedirs(self.data_dir)
+
         if not self.log_db_path:
             if self.data_dir:
                 self.log_db_path = os.path.join(self.data_dir, 'actions.db')
@@ -57,10 +61,6 @@ class WebInterfaceNode(Node):
                 self.log_db_path = os.path.join(os.getcwd(), 'actions.db')
 
         self.action_logger = ActionLogger(self.log_db_path)
-        
-        # Create data directory if it doesn't exist
-        if self.data_dir and not os.path.exists(self.data_dir):
-            os.makedirs(self.data_dir)
             
         # Initialize CV bridge
         self.bridge = CvBridge()
@@ -478,6 +478,7 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     finally:
+        node.action_logger.close()
         node.destroy_node()
         rclpy.shutdown()
 

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -71,6 +71,16 @@ def test_action_logger_basic(tmp_path):
     assert json.loads(row[1]) == {'item': 1}
 
 
+def test_action_logger_close(tmp_path):
+    db_path = tmp_path / 'actions.db'
+    with ActionLogger(str(db_path)) as logger:
+        logger.log('foo')
+    assert logger._conn is None
+    conn = sqlite3.connect(db_path)
+    count = conn.execute('SELECT COUNT(*) FROM actions').fetchone()[0]
+    assert count == 1
+
+
 def test_scenario_file_cycle(tmp_path):
     dummy = make_dummy(tmp_path)
 


### PR DESCRIPTION
## Summary
- add closing logic and context manager support to `ActionLogger`
- create data directory before logging setup in `WebInterfaceNode`
- close the `ActionLogger` on shutdown
- test closing behaviour

## Testing
- `pip install pyyaml --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d6588bb4833193112d235ec3ba29