### PR TITLE
Clamp error simulation rate and add bounds test

### DIFF
--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -267,7 +267,8 @@ class EnvironmentConfiguratorNode(Node):
             self.physics_enabled = sim_settings.get('physics_enabled', self.physics_enabled)
             self.record_metrics = sim_settings.get('record_metrics', self.record_metrics)
             # Value should be between 0 and 1
-            self.error_simulation_rate = sim_settings.get('error_simulation_rate', self.error_simulation_rate)
+            rate = sim_settings.get('error_simulation_rate', self.error_simulation_rate)
+            self.error_simulation_rate = max(0.0, min(rate, 1.0))
         
         self.get_logger().info('Updated settings')
     

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -107,3 +107,18 @@ def test_load_missing_uses_default(tmp_path):
     ec.EnvironmentConfiguratorNode.load_scenario(dummy, 'missing')
     default = ec.EnvironmentConfiguratorNode.get_default_config(dummy)
     assert dummy.environment_config['description'] == default['description']
+
+
+def test_error_sim_rate_bounds(tmp_path):
+    dummy = make_dummy(tmp_path)
+    ec.EnvironmentConfiguratorNode.update_settings(
+        dummy,
+        {'simulation': {'error_simulation_rate': 1.5}}
+    )
+    assert dummy.error_simulation_rate == 1.0
+
+    ec.EnvironmentConfiguratorNode.update_settings(
+        dummy,
+        {'simulation': {'error_simulation_rate': -0.5}}
+    )
+    assert dummy.error_simulation_rate == 0.0


### PR DESCRIPTION
## Summary
- restrict `error_simulation_rate` between 0.0 and 1.0
- test that the clamping logic works correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d669ae4c833198b301c6e2ea3798