### PR TITLE
Add WebInterface place API test

### DIFF
--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -1,0 +1,114 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure packages under src/ are importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'src'))
+
+
+def _setup_ros_stubs(monkeypatch):
+    """Create minimal ROS stubs so WebInterfaceNode can be imported."""
+    rclpy_stub = types.ModuleType('rclpy')
+    node_mod = types.ModuleType('rclpy.node')
+
+    class DummyNode:
+        def __init__(self, *args, **kwargs):
+            self.params = {}
+
+        def declare_parameters(self, ns, params):
+            for name, value in params:
+                self.params[name] = value
+
+        def get_parameter(self, name):
+            class P:
+                def __init__(self, value):
+                    self.value = value
+            return P(self.params.get(name))
+
+        def create_publisher(self, *args, **kwargs):
+            pub = MagicMock()
+            pub._topic = args[1] if len(args) > 1 else kwargs.get('topic')
+            return pub
+
+        def create_subscription(self, *args, **kwargs):
+            return MagicMock()
+
+        def create_timer(self, *args, **kwargs):
+            return MagicMock()
+
+        def get_logger(self):
+            class Logger:
+                def info(self, *a, **k):
+                    pass
+                def error(self, *a, **k):
+                    pass
+            return Logger()
+
+    node_mod.Node = DummyNode
+    rclpy_stub.node = node_mod
+    rclpy_stub.init = lambda *a, **kw: None
+    rclpy_stub.shutdown = lambda *a, **kw: None
+
+    monkeypatch.setitem(sys.modules, 'rclpy', rclpy_stub)
+    monkeypatch.setitem(sys.modules, 'rclpy.node', node_mod)
+
+    std_msgs_stub = types.ModuleType('std_msgs')
+    std_msgs_stub.msg = types.ModuleType('std_msgs.msg')
+
+    class Msg:
+        def __init__(self):
+            self.data = ''
+
+    std_msgs_stub.msg.String = Msg
+    std_msgs_stub.msg.Bool = Msg
+    monkeypatch.setitem(sys.modules, 'std_msgs', std_msgs_stub)
+    monkeypatch.setitem(sys.modules, 'std_msgs.msg', std_msgs_stub.msg)
+
+    sensor_stub = types.ModuleType('sensor_msgs')
+    sensor_stub.msg = types.ModuleType('sensor_msgs.msg')
+    sensor_stub.msg.Image = Msg
+    monkeypatch.setitem(sys.modules, 'sensor_msgs', sensor_stub)
+    monkeypatch.setitem(sys.modules, 'sensor_msgs.msg', sensor_stub.msg)
+
+    cv_bridge_stub = types.ModuleType('cv_bridge')
+    class CvBridge:
+        def imgmsg_to_cv2(self, *a, **k):
+            return None
+    cv_bridge_stub.CvBridge = CvBridge
+    monkeypatch.setitem(sys.modules, 'cv_bridge', cv_bridge_stub)
+
+    ament_stub = types.ModuleType('ament_index_python')
+    ament_stub.packages = types.ModuleType('ament_index_python.packages')
+
+    def get_pkg_share(_):
+        return str(ROOT / 'src' / 'simulation_tools')
+    ament_stub.packages.get_package_share_directory = get_pkg_share
+    monkeypatch.setitem(sys.modules, 'ament_index_python', ament_stub)
+    monkeypatch.setitem(sys.modules, 'ament_index_python.packages', ament_stub.packages)
+
+
+def test_place_api_publishes_and_logs(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    from simulation_tools.simulation_tools import web_interface_node as win
+
+    logger_mock = MagicMock()
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock(return_value=logger_mock))
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+
+    res = client.post('/api/place', json={'location': 'bin_red'})
+    assert res.status_code == 200
+
+    assert node.command_pub.publish.called
+    msg = node.command_pub.publish.call_args[0][0]
+    assert msg.data == 'place bin_red'
+    assert node.command_pub._topic == '/simulation/command'
+
+    logger_mock.log.assert_called_once_with('place', {'location': 'bin_red'})


### PR DESCRIPTION
## Summary
- add tests for WebInterface `/api/place`
- stub ROS modules so WebInterfaceNode can be imported without ROS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d7cbec9c8331ae032237d0bf6c00