### PR TITLE
Set save_images default to False

### DIFF
--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
         ),
     )
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
-    save_images = LaunchConfiguration('save_images', default='true')
+    save_images = LaunchConfiguration('save_images', default='false')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
 
@@ -61,7 +61,7 @@ def generate_launch_description():
             description='Directory for storing data and exports'),
         DeclareLaunchArgument(
             'save_images',
-            default_value='true',
+            default_value='false',
             description='Save latest images to disk'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -14,7 +14,7 @@ def generate_launch_description():
     config_dir = LaunchConfiguration('config_dir', default=os.path.join(
         get_package_share_directory('simulation_tools'), 'config'))
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
-    save_images = LaunchConfiguration('save_images', default='true')
+    save_images = LaunchConfiguration('save_images', default='false')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
     opcua_port = LaunchConfiguration('opcua_port', default='4840')
 
@@ -49,7 +49,7 @@ def generate_launch_description():
             description='Directory for storing data and exports'),
         DeclareLaunchArgument(
             'save_images',
-            default_value='true',
+            default_value='false',
             description='Save latest images to disk'),
         DeclareLaunchArgument(
             'allow_unsafe_werkzeug',

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -33,7 +33,7 @@ class WebInterfaceNode(Node):
             'host': '0.0.0.0',
             'config_dir': '',
             'data_dir': '',
-            'save_images': True,
+            'save_images': False,
             'allow_unsafe_werkzeug': True,
             'log_db_path': '',
             'jpeg_quality': 75,

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -155,7 +155,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
                 'host': '0.0.0.0',
                 'config_dir': '',
                 'data_dir': str(data_dir),
-                'save_images': True,
+                'save_images': False,
                 'allow_unsafe_werkzeug': True,
                 'log_db_path': '',
                 'jpeg_quality': 75,
@@ -276,3 +276,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
     finally:
         for name in stub_modules.keys():
             sys.modules.pop(name, None)
+        sys.modules.pop('simulation_tools.simulation_tools.web_interface_node', None)
+        pkg = sys.modules.get('simulation_tools.simulation_tools')
+        if pkg and hasattr(pkg, 'web_interface_node'):
+            delattr(pkg, 'web_interface_node')

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -70,7 +70,7 @@ def test_web_interface_node_defaults():
     from simulation_tools.web_interface_node import WebInterfaceNode
     node = _init_node(WebInterfaceNode)
     assert node.get_parameter('allow_unsafe_werkzeug').value is True
-    assert node.get_parameter('save_images').value is True
+    assert node.get_parameter('save_images').value is False
     assert node.get_parameter('log_db_path').value == ''
     assert node.get_parameter('jpeg_quality').value == 75
 


### PR DESCRIPTION
## Summary
- default `save_images` parameter to `False` in `WebInterfaceNode`
- update launch files with the new default
- adjust tests for new `save_images` behavior
- clean up test module loading to avoid cross-test side effects

## Testing
- `flake8 src/simulation_tools/simulation_tools/web_interface_node.py tests/test_nodes.py tests/test_core_logic.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846f4541ee48331a579a20bd6f65c6f