### PR TITLE
Fix empty YAML handling

### DIFF
--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -209,8 +209,10 @@ class EnvironmentConfiguratorNode(Node):
             if os.path.exists(scenario_path):
                 try:
                     with open(scenario_path, 'r') as f:
-                        self.environment_config = yaml.safe_load(f)
-                        self.get_logger().info(f'Loaded scenario from {scenario_path}')
+                        self.environment_config = yaml.safe_load(f) or {}
+                        self.get_logger().info(
+                            f'Loaded scenario from {scenario_path}'
+                        )
                         return
                 except Exception as e:
                     self.get_logger().error(f'Error loading scenario file {scenario}: {e}')

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -117,6 +117,13 @@ def test_load_missing_uses_default(tmp_path):
     assert dummy.environment_config['description'] == default['description']
 
 
+def test_empty_yaml_results_in_empty_config(tmp_path):
+    dummy = make_dummy(tmp_path)
+    (tmp_path / 'empty.yaml').write_text('')
+    ec.EnvironmentConfiguratorNode.load_scenario(dummy, 'empty')
+    assert dummy.environment_config == {}
+
+
 def test_error_sim_rate_bounds(tmp_path):
     dummy = make_dummy(tmp_path)
     ec.EnvironmentConfiguratorNode.update_settings(


### PR DESCRIPTION
## Summary
- handle empty YAML scenario files gracefully
- test empty YAML loads as empty config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fa2d70d48331b8c97bc801193345