### PR TITLE
Replace deprecated warn logging

### DIFF
--- a/src/advanced_perception/advanced_perception/pose_estimation_node.py
+++ b/src/advanced_perception/advanced_perception/pose_estimation_node.py
@@ -98,7 +98,7 @@ class PoseEstimationNode(Node):
         Load pose estimation configuration from YAML file
         """
         if not self.pose_estimation_config_path:
-            self.get_logger().warn('No pose estimation config file provided, using default values')
+            self.get_logger().warning('No pose estimation config file provided, using default values')
             self.min_depth = 0.1
             self.max_depth = 5.0
             self.depth_scale = 0.001  # Convert mm to meters

--- a/src/advanced_perception/advanced_perception/segmentation_node.py
+++ b/src/advanced_perception/advanced_perception/segmentation_node.py
@@ -64,7 +64,7 @@ class SegmentationNode(Node):
         Load segmentation configuration from YAML file
         """
         if not self.segmentation_config_path:
-            self.get_logger().warn('No segmentation config file provided, using default values')
+            self.get_logger().warning('No segmentation config file provided, using default values')
             self.threshold_min = np.array([0, 0, 0])
             self.threshold_max = np.array([255, 255, 255])
             self.min_contour_area = 1000

--- a/src/apm_core/apm_core/onnx_inference_node.py
+++ b/src/apm_core/apm_core/onnx_inference_node.py
@@ -264,7 +264,7 @@ class OnnxInferenceNode(Node):
     def perform_inference(self, image, header):
         """Perform object detection inference on the image."""
         if self.session is None:
-            self.get_logger().warn('ONNX session not initialized, skipping inference')
+            self.get_logger().warning('ONNX session not initialized, skipping inference')
             return
         
         try:

--- a/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
+++ b/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
@@ -145,7 +145,7 @@ class FMMMoveitInterfaceNode(Node):
         Callback for pick commands
         """
         if self.current_state != "idle":
-            self.get_logger().warn(f"Cannot execute pick command, current state: {self.current_state}")
+            self.get_logger().warning(f"Cannot execute pick command, current state: {self.current_state}")
             return
         
         self.current_state = "picking"
@@ -169,7 +169,7 @@ class FMMMoveitInterfaceNode(Node):
         Callback for place commands
         """
         if self.current_state != "idle":
-            self.get_logger().warn(f"Cannot execute place command, current state: {self.current_state}")
+            self.get_logger().warning(f"Cannot execute place command, current state: {self.current_state}")
             return
         
         self.current_state = "placing"

--- a/src/fmm_core/fmm_core/pick_and_place_node.py
+++ b/src/fmm_core/fmm_core/pick_and_place_node.py
@@ -180,7 +180,7 @@ class PickAndPlaceNode(Node):
         Callback for pick commands
         """
         if self.current_state != "idle":
-            self.get_logger().warn(f"Cannot execute pick command, current state: {self.current_state}")
+            self.get_logger().warning(f"Cannot execute pick command, current state: {self.current_state}")
             return
         
         self.current_state = "picking"
@@ -204,11 +204,11 @@ class PickAndPlaceNode(Node):
         Callback for place commands
         """
         if self.current_state != "idle":
-            self.get_logger().warn(f"Cannot execute place command, current state: {self.current_state}")
+            self.get_logger().warning(f"Cannot execute place command, current state: {self.current_state}")
             return
         
         if self.attached_object_id is None:
-            self.get_logger().warn("No object attached to end effector")
+            self.get_logger().warning("No object attached to end effector")
             self.publish_status("error")
             return
         

--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -119,7 +119,7 @@ class EnvironmentConfiguratorNode(Node):
         
         elif command == 'emergency_stop':
             self.running = False
-            self.get_logger().warn('Emergency stop triggered')
+            self.get_logger().warning('Emergency stop triggered')
         
         elif command == 'start_recording':
             self.get_logger().info('Starting recording')
@@ -249,7 +249,7 @@ class EnvironmentConfiguratorNode(Node):
         
         # Don't delete default scenario
         if scenario_id == 'default':
-            self.get_logger().warn('Cannot delete default scenario')
+            self.get_logger().warning('Cannot delete default scenario')
             return
         
         scenario_path = os.path.join(self.config_dir, f'{scenario_id}.yaml')

--- a/src/simulation_tools/simulation_tools/industrial_protocol_bridge_node.py
+++ b/src/simulation_tools/simulation_tools/industrial_protocol_bridge_node.py
@@ -155,7 +155,7 @@ class IndustrialProtocolBridgeNode(Node):
     
     def on_mqtt_disconnect(self, client, userdata, rc):
         if rc != 0:
-            self.get_logger().warn(f'MQTT disconnected with result code {rc}')
+            self.get_logger().warning(f'MQTT disconnected with result code {rc}')
             # Try to reconnect
             try:
                 client.reconnect()

--- a/src/simulation_tools/simulation_tools/safety_monitor_node.py
+++ b/src/simulation_tools/simulation_tools/safety_monitor_node.py
@@ -179,7 +179,7 @@ class SafetyMonitorNode(Node):
             return
         
         self.emergency_stop_active = True
-        self.get_logger().warn(f'Emergency stop triggered: {reason}')
+        self.get_logger().warning(f'Emergency stop triggered: {reason}')
         
         # Publish emergency stop
         stop_msg = Bool()
@@ -200,7 +200,7 @@ class SafetyMonitorNode(Node):
         
         # Check if it's safe to reset
         if reset_requires_confirmation and self.safety_violations:
-            self.get_logger().warn('Cannot reset emergency stop: safety violations still present')
+            self.get_logger().warning('Cannot reset emergency stop: safety violations still present')
             return
         
         self.emergency_stop_active = False

--- a/src/simulation_tools/simulation_tools/system_test_node.py
+++ b/src/simulation_tools/simulation_tools/system_test_node.py
@@ -62,7 +62,7 @@ class SystemTestNode(Node):
     
     def start_test(self):
         if self.test_running:
-            self.get_logger().warn('Test already running')
+            self.get_logger().warning('Test already running')
             return
         
         self.test_running = True


### PR DESCRIPTION
## Summary
- use `get_logger().warning` everywhere instead of deprecated `warn`
- keep behaviour the same

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fa55670c833188b4578cdea4503a