### PR TITLE
Switch to yaml.safe_dump

### DIFF
--- a/src/simulation_tools/config/create_default_config.py
+++ b/src/simulation_tools/config/create_default_config.py
@@ -81,6 +81,6 @@ os.makedirs(os.path.dirname(os.path.abspath(__file__)), exist_ok=True)
 
 # Write default configuration to file
 with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default.yaml'), 'w') as f:
-    yaml.dump(default_config, f, default_flow_style=False)
+    yaml.safe_dump(default_config, f, default_flow_style=False)
 
 print("Default configuration created successfully.")

--- a/src/simulation_tools/simulation_tools/environment_configurator_node.py
+++ b/src/simulation_tools/simulation_tools/environment_configurator_node.py
@@ -239,7 +239,7 @@ class EnvironmentConfiguratorNode(Node):
         
         try:
             with open(scenario_path, 'w') as f:
-                yaml.dump(config, f, default_flow_style=False)
+                yaml.safe_dump(config, f, default_flow_style=False)
             self.get_logger().info(f'Saved scenario to {scenario_path}')
         except Exception as e:
             self.get_logger().error(f'Error saving scenario file {scenario_id}: {e}')


### PR DESCRIPTION
## Summary
- use `yaml.safe_dump` in the environment configurator node
- use `yaml.safe_dump` when creating the default configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ff9da34c833189528b3206c039cc