### PR TITLE
Document config directory options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ The mesh resources are required for accurate visualization in both cases.
        opcua_endpoint:=opc.tcp://0.0.0.0:4840/freeopcua/server/
    ```
 
+### Configuration Directory and Data Storage
+
+By default, configuration files are loaded from
+`src/simulation_tools/config/`. Pass `config_dir:=<path>` when launching to
+use a custom directory. The `data_dir` parameter controls where log files and
+optional saved images are written (default: `/tmp/simulation_data`).
+
+Example:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py \
+    config_dir:=/my/configs data_dir:=/tmp/my_data
+```
+
+Scenario YAML files such as `pick_and_place.yaml` can be duplicated and
+modified in your custom directory to define new scenarios.
+
 3. **Access the Web Interface**
    ```
    http://localhost:8080

--- a/tests/test_pose_estimation_node_fallback.py
+++ b/tests/test_pose_estimation_node_fallback.py
@@ -78,6 +78,7 @@ def _setup_stubs(monkeypatch):
     monkeypatch.setitem(sys.modules, 'geometry_msgs.msg', geometry_stub.msg)
 
     cv_bridge_stub = types.ModuleType('cv_bridge')
+
     class DummyBridge:
         def imgmsg_to_cv2(self, *a, **k):
             return np.zeros((10, 10), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- document configuration directory and data storage settings in README
- fix flake8 style error

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482a41b31883318b655f494739304b