### PR TITLE
Update README with rosdep instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ The mesh resources are required for accurate visualization in both cases.
    source /opt/ros/humble/setup.bash
    cd industrial_robotics_simulation_platform
    pip install -r requirements.txt
+   sudo apt install python3-rosdep
+   sudo rosdep init
+   rosdep update
+   rosdep install --from-paths src -y --ignore-src
    colcon build --symlink-install
    source install/setup.bash
    ```
+   The `rosdep` commands resolve additional ROS packages required for the workspace.
 
 2. **Launch the System**
    ```bash


### PR DESCRIPTION
## Summary
- add rosdep initialization steps in installation section of README

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError for yaml and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68485428ba808331a34b93fc42337546