### PR TITLE
Add detected-object support to web interface

### DIFF
--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -40,6 +40,8 @@ class DummyLogger:
         pass
     def warn(self, *args, **kwargs):
         pass
+    def warning(self, *args, **kwargs):
+        pass
 
 
 class DummyEC(ec.EnvironmentConfiguratorNode):
@@ -164,6 +166,8 @@ def test_web_interface_logger_initialization_order(tmp_path):
             pass
         def warn(self, *a, **k):
             pass
+        def warning(self, *a, **k):
+            pass
 
     class DummyNode:
         def __init__(self, name):
@@ -176,6 +180,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
                 'allow_unsafe_werkzeug': True,
                 'log_db_path': '',
                 'jpeg_quality': 75,
+                'detected_objects_topic': '/apm/detection/objects',
             }
 
         def declare_parameters(self, ns, params):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -73,6 +73,10 @@ def test_web_interface_node_defaults():
     assert node.get_parameter('save_images').value is False
     assert node.get_parameter('log_db_path').value == ''
     assert node.get_parameter('jpeg_quality').value == 75
+    assert (
+        node.get_parameter('detected_objects_topic').value
+        == '/apm/detection/objects'
+    )
 
 
 def test_visualization_server_node_defaults():


### PR DESCRIPTION
## Summary
- subscribe to detected objects and expose via `/api/objects`
- add `/api/pick` endpoint
- expose `detected_objects_topic` parameter
- test new API routes and update default parameter tests

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848973fae448331b6b9e9e98d28f427