### PR TITLE
Fix xacro warning and flake8 issue

### DIFF
--- a/src/ur5_robot_description/urdf/ur5_robot.urdf.xacro
+++ b/src/ur5_robot_description/urdf/ur5_robot.urdf.xacro
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5">
   <!-- Common properties -->
-  <xacro:property name="pi" value="3.14159265359" />
   
   <!-- UR5 specific properties -->
   <xacro:property name="shoulder_height" value="0.089159" />

--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -48,6 +48,7 @@ def _setup_ros_stubs(monkeypatch):
 
                 def error(self, *a, **k):
                     pass
+
                 def warning(self, *a, **k):
                     pass
             return Logger()


### PR DESCRIPTION
## Summary
- remove `pi` property from URDF xacro to silence warning
- fix flake8 style error in `test_web_interface_api.py`

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68489aa9bf8c833193094d806419ad34