### PR TITLE
Launch UR5 with RViz

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ source install/setup.bash
 
 ## Visualizing the UR5
 
-Once the meshes are in place, you can visualize the UR5 model in RViz:
+Once the meshes are in place, you can visualize the UR5 model in RViz. Running
+the following command now starts RViz automatically with a default
+configuration:
 
 ```bash
 ros2 launch ur5_robot_description display.launch.py

--- a/src/ur5_robot_description/config/ur5.rviz
+++ b/src/ur5_robot_description/config/ur5.rviz
@@ -1,0 +1,48 @@
+Visualize:
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Visualization Manager:
+    Class: ""
+    Displays:
+      - Class: rviz_default_plugins/RobotModel
+        Enabled: true
+        Name: Robot Model
+      - Class: rviz_default_plugins/Grid
+        Enabled: true
+        Name: Grid
+    Global Options:
+      Fixed Frame: base_link
+      Background Color: 48; 48; 48
+      Frame Rate: 30

--- a/src/ur5_robot_description/launch/display.launch.py
+++ b/src/ur5_robot_description/launch/display.launch.py
@@ -40,6 +40,17 @@ def generate_launch_description():
             {'use_sim_time': use_sim_time}
         ]
     )
+
+    # RViz2 node
+    rviz_config = os.path.join(pkg_share, 'config', 'ur5.rviz')
+    rviz2 = Node(
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        output='screen',
+        parameters=[{'use_sim_time': use_sim_time}],
+        arguments=['-d', rviz_config]
+    )
     
     # Return the launch description
     return LaunchDescription([
@@ -49,5 +60,6 @@ def generate_launch_description():
             description='Use simulation time'
         ),
         robot_state_publisher,
-        joint_state_publisher
+        joint_state_publisher,
+        rviz2
     ])

--- a/src/ur5_robot_description/package.xml
+++ b/src/ur5_robot_description/package.xml
@@ -14,6 +14,7 @@
   <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <depend>joint_state_publisher_gui</depend>
+  <depend>rviz2</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- display the UR5 in RViz using an included config
- add rviz2 dependency
- document RViz auto-launch in README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa0a453988331a10a0a28a572d22e