### PR TITLE
Add instructions for UR5 meshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,23 @@ The Industrial Robotics Simulation Platform is a comprehensive, highly configura
 
 ## UR5 Mesh Assets
 
-The UR5 mesh files used by `ur5_robot_description` are automatically downloaded
-or bundled with this repository. No manual download or CMake modification is
-required. Once dependencies are installed, build the workspace:
+The UR5 mesh files used by `ur5_robot_description` are not stored directly in
+this repository. Install the `ur_description` package for your ROS&nbsp;2
+distribution so that these meshes are available. On Ubuntu you can install the
+package with:
+
+```bash
+sudo apt-get install ros-<distro>-ur-description
+```
+
+The mesh files will then be located under
+`/opt/ros/<distro>/share/ur_description/meshes`. If you build
+`ur_description` from source or place the meshes elsewhere, make sure the path
+is reachable via `ROS_PACKAGE_PATH` or copy the meshes into
+`src/ur5_robot_description/meshes`.
+
+Once the package is installed and other dependencies are available, build the
+workspace:
 
 ```bash
 source /opt/ros/humble/setup.bash

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -109,10 +109,21 @@ pip3 install asyncua paho-mqtt  # For industrial protocol support
 
 ### UR5 Mesh Assets
 
-The UR5 mesh files required by `ur5_robot_description` are automatically
-downloaded or included with the repository. Manual download and CMake
-modifications are unnecessary. After installing dependencies, build the
-workspace:
+The UR5 meshes are provided by the `ur_description` package for your ROS 2
+distribution. Install this package using apt so that the URDF can locate the
+meshes:
+
+```bash
+sudo apt-get install ros-<distro>-ur-description
+```
+
+The meshes will then reside under
+`/opt/ros/<distro>/share/ur_description/meshes`. If you built the package from
+source or installed it to a custom location, ensure that directory is included
+in your `ROS_PACKAGE_PATH` or create a symlink to
+`src/ur5_robot_description/meshes`.
+
+After installing dependencies and the package, build the workspace:
 
 ```bash
 source /opt/ros/humble/setup.bash


### PR DESCRIPTION
## Summary
- clarify UR5 mesh installation in README and deployment guide
- provide apt command, path location, and notes on custom locations

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684aa2c323948331b25b7ff953d83cda