### PR TITLE
Add safety_rules config

### DIFF
--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -160,6 +160,7 @@ The system can be configured through YAML files located in the `config` director
 - `default_sorting_config.yaml`: Object sorting parameters
 - `safety_rules.yaml`: Safety monitoring rules
 - `*.yaml`: Scenario configuration files
+The **safety_rules.yaml** file defines the default collision detection, safety zones, and emergency stop behavior loaded by the Safety Monitor Node. Modify this file to customize safety constraints for your deployment.
 
 ### Camera Configuration
 

--- a/src/simulation_tools/config/safety_rules.yaml
+++ b/src/simulation_tools/config/safety_rules.yaml
@@ -1,0 +1,21 @@
+collision_detection:
+  enabled: true
+  min_distance: 0.1
+  objects:
+    - robot
+    - human
+    - obstacle
+safety_zones:
+  - name: robot_workspace
+    type: cylinder
+    center: [0.0, 0.0, 0.0]
+    radius: 1.0
+    height: 2.0
+    restricted_objects:
+      - human
+emergency_stop:
+  auto_triggers:
+    - collision
+    - zone_violation
+    - speed_violation
+  reset_requires_confirmation: true


### PR DESCRIPTION
## Summary
- add default safety_rules.yaml configuration
- document safety_rules.yaml in the deployment guide

## Testing
- `pip install -q -r requirements.txt` *(fails: No matching distribution found for rclpy)*
- `pytest -q` *(fails: ModuleNotFoundError for yaml/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684aa9bb9150833190ad7df3f56b9e8c