### PR TITLE
Update start command instructions

### DIFF
--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -27,6 +27,14 @@ ros2 launch simulation_tools integrated_system_launch.py \
     use_realsense:=false use_advanced_perception:=true
 ```
 
+To begin publishing camera data and metrics, send a start command:
+
+```bash
+ros2 topic pub /simulation/command std_msgs/msg/String '{data: "start"}'
+```
+
+Using the "Start" button on the web interface performs the same action.
+
 This also starts the Flask-based web interface on port `8080`.
 
 ## 3. Launch Object Detection


### PR DESCRIPTION
## Summary
- add instructions for sending a start command when running the integrated system
- note that the web UI's Start button does the same thing

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for rclpy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684aec3872b083318ec57ce02ffa8ade