### PR TITLE
Add setup.cfg for apm_core

### DIFF
--- a/src/apm_core/setup.cfg
+++ b/src/apm_core/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/apm_core
+[install]
+install_scripts=$base/lib/apm_core


### PR DESCRIPTION
## Summary
- configure `apm_core` install/ develop paths via setup.cfg

## Testing
- `pip install numpy pyyaml opencv-python flask flask-socketio matplotlib asyncua paho-mqtt onnxruntime`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af175c23883319e8a6fae5a46f904