### PR TITLE
Improve web UI with optional browser launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=
 Both `web_interface_node` and `visualization_server_node` support a `jpeg_quality`
 parameter to control JPEG compression (0-100). The default value is `75`.
 
+Set `auto_open_browser:=true` to automatically open your default web browser
+when the interface starts. This is disabled by default for headless systems.
+
 ## Documentation
 
 For complete details, please refer to the included `industrial_deployment_guide.md` which provides comprehensive instructions for:

--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -12,6 +12,7 @@ import json
 import threading
 import time
 import shutil
+import webbrowser
 from flask import Flask, render_template, request, jsonify, send_from_directory
 from flask_socketio import SocketIO
 import cv2
@@ -44,6 +45,7 @@ class WebInterfaceNode(Node):
             'log_db_path': '',
             'jpeg_quality': 75,
             'detected_objects_topic': '/apm/detection/objects',
+            'auto_open_browser': False,
         }
         self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         
@@ -57,6 +59,7 @@ class WebInterfaceNode(Node):
         self.log_db_path = self.get_parameter('log_db_path').value
         self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
         self.detected_objects_topic = self.get_parameter('detected_objects_topic').value
+        self.auto_open_browser = self.get_parameter('auto_open_browser').value
 
         if not self.log_db_path:
             if self.data_dir:
@@ -149,6 +152,10 @@ class WebInterfaceNode(Node):
         self.server_thread = threading.Thread(target=self.run_server)
         self.server_thread.daemon = True
         self.server_thread.start()
+
+        if self.auto_open_browser:
+            url = f'http://{self.host}:{self.port}'
+            threading.Thread(target=webbrowser.open, args=(url,), daemon=True).start()
         
         self.get_logger().info(f'Web interface started at http://{self.host}:{self.port}')
     

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -181,6 +181,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
                 'log_db_path': '',
                 'jpeg_quality': 75,
                 'detected_objects_topic': '/apm/detection/objects',
+                'auto_open_browser': False,
             }
 
         def declare_parameters(self, ns, params):


### PR DESCRIPTION
## Summary
- add optional `auto_open_browser` parameter to the web interface
- document the new option in README
- ensure tests handle the new parameter

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d1b71848331b6d91d23c2af3ddf