### PR TITLE
Fix warning logger call

### DIFF
--- a/src/simulation_tools/simulation_tools/camera_simulator_node.py
+++ b/src/simulation_tools/simulation_tools/camera_simulator_node.py
@@ -35,7 +35,7 @@ class CameraSimulatorNode(Node):
         self.simulation_mode = self.get_parameter('simulation_mode').value
         self.frame_rate = self.get_parameter('frame_rate').value
         if self.frame_rate <= 0:
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f'Invalid frame_rate {self.frame_rate}, using 30.0 instead'
             )
             self.frame_rate = 30.0

--- a/tests/test_camera_simulator_node.py
+++ b/tests/test_camera_simulator_node.py
@@ -17,6 +17,7 @@ def _setup_stubs(monkeypatch):
         def __init__(self):
             self.info = MagicMock()
             self.warn = MagicMock()
+            self.warning = MagicMock()
             self.error = MagicMock()
 
     class DummyNode:
@@ -105,6 +106,6 @@ def test_frame_rate_zero_warns(monkeypatch):
 
     node = csn.CameraSimulatorNode()
     logger = node.get_logger()
-    logger.warn.assert_called_once()
-    assert 'Invalid frame_rate' in logger.warn.call_args[0][0]
+    logger.warning.assert_called_once()
+    assert 'Invalid frame_rate' in logger.warning.call_args[0][0]
     assert node.frame_rate == 30.0


### PR DESCRIPTION
## Summary
- fix logger method to use `warning`
- update tests for new logger behavior

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5026aa4883318f0bcfa84af0d98b