### PR TITLE
Add shutdown routine for web interface

### DIFF
--- a/src/simulation_tools/simulation_tools/web_interface_node.py
+++ b/src/simulation_tools/simulation_tools/web_interface_node.py
@@ -610,6 +610,16 @@ class WebInterfaceNode(Node):
             allow_unsafe_werkzeug=self.allow_unsafe_werkzeug,
         )
 
+    def shutdown(self):
+        """Stop the Socket.IO server and wait for its thread to finish."""
+        try:
+            self.socketio.stop()
+        except Exception as e:  # pragma: no cover - best effort shutdown
+            self.get_logger().error(f'Error stopping SocketIO server: {e}')
+        # Ensure the server thread is joined to avoid dangling threads
+        if self.server_thread.is_alive():
+            self.server_thread.join()
+
 def main(args=None):
     rclpy.init(args=args)
     node = WebInterfaceNode()
@@ -620,6 +630,7 @@ def main(args=None):
         pass
     finally:
         node.action_logger.close()
+        node.shutdown()
         node.destroy_node()
         rclpy.shutdown()
 


### PR DESCRIPTION
## Summary
- add shutdown method to stop Socket.IO and join server thread
- call node.shutdown() before destroying the node in `main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5063945c8331b87563531162329e