### PR TITLE
Fix URDF parameter with namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ ros2 launch ur5_robot_moveit_config move_group.launch.py use_sim_time:=false
 The mesh resources are required for accurate visualization in both cases.
 
 - If RViz opens without showing the robot, confirm you have a working graphical desktop and that the workspace has been built and sourced.
+- The launch file now passes the URDF to RViz directly so the model also loads correctly when a namespace is specified, e.g. `ros2 launch ur5_robot_description display.launch.py --ros-args -r __ns:=my_robot`.
 
 ## Getting Started
 

--- a/src/delta_robot_description/launch/display.launch.py
+++ b/src/delta_robot_description/launch/display.launch.py
@@ -18,7 +18,8 @@ def generate_launch_description():
     # Get the URDF file
     urdf_file = os.path.join(pkg_share, 'urdf', 'delta_robot.urdf.xacro')
     
-    # Parse the URDF
+    # Parse the URDF once so both RViz and the state publisher share the same
+    # description even when a namespace is specified.
     robot_description_content = Command([
         'xacro ', urdf_file
     ])
@@ -64,7 +65,8 @@ def generate_launch_description():
         name='rviz2',
         output='screen',
         parameters=[{
-            'use_sim_time': use_sim_time
+            'use_sim_time': use_sim_time,
+            'robot_description': robot_description_content
         }],
         arguments=['-d', os.path.join(pkg_share, 'config', 'delta_robot.rviz')]
     )

--- a/src/delta_robot_description/launch/display_headless.launch.py
+++ b/src/delta_robot_description/launch/display_headless.launch.py
@@ -17,7 +17,9 @@ def generate_launch_description():
     # Get the URDF file
     urdf_file = os.path.join(pkg_share, 'urdf', 'delta_robot.urdf.xacro')
     
-    # Parse the URDF
+    # Parse the URDF once so other nodes (for example RViz if launched
+    # separately) can receive the same robot description when a namespace is
+    # provided.
     robot_description_content = Command([
         'xacro ', urdf_file
     ])

--- a/src/ur5_robot_description/launch/display.launch.py
+++ b/src/ur5_robot_description/launch/display.launch.py
@@ -18,6 +18,10 @@ def generate_launch_description():
     # Load URDF file
     urdf_file = os.path.join(pkg_share, 'urdf', 'ur5_robot.urdf.xacro')
     
+    # Generate robot description once so both RViz and the state publisher
+    # receive the same parameter even when a namespace is used.
+    robot_description_content = launch.substitutions.Command(['xacro ', urdf_file])
+
     # Robot state publisher node
     robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -26,7 +30,7 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'use_sim_time': use_sim_time},
-            {'robot_description': launch.substitutions.Command(['xacro ', urdf_file])}
+            {'robot_description': robot_description_content}
         ]
     )
     
@@ -48,7 +52,10 @@ def generate_launch_description():
         executable='rviz2',
         name='rviz2',
         output='screen',
-        parameters=[{'use_sim_time': use_sim_time}],
+        parameters=[
+            {'use_sim_time': use_sim_time},
+            {'robot_description': robot_description_content}
+        ],
         arguments=['-d', rviz_config]
     )
     


### PR DESCRIPTION
## Summary
- ensure URDF is provided to RViz when using namespaces
- document the behavior in the README

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for rclpy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684c665904648331a0a5509d142d6db3