### PR TITLE
Add action fetch helper

### DIFF
--- a/src/simulation_tools/simulation_tools/action_logger.py
+++ b/src/simulation_tools/simulation_tools/action_logger.py
@@ -57,3 +57,23 @@ class ActionLogger:
     def __exit__(self, exc_type, exc, tb):
         self.close()
         return False
+
+    def get_recent_actions(self, limit: int = 100):
+        """Return the most recent actions as a list of dictionaries."""
+        with self._lock:
+            if self._conn is None:
+                raise sqlite3.Error("Database connection is closed")
+            cursor = self._conn.execute(
+                "SELECT timestamp, action, details FROM actions ORDER BY id DESC LIMIT ?",
+                (limit,),
+            )
+            rows = cursor.fetchall()
+
+        actions = []
+        for timestamp, action, details in rows:
+            actions.append({
+                "timestamp": timestamp,
+                "action": action,
+                "details": json.loads(details) if details else None,
+            })
+        return actions

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -91,6 +91,18 @@ def test_action_logger_handles_db_error(tmp_path):
     assert count == 0
 
 
+def test_action_logger_get_recent(tmp_path):
+    db_path = tmp_path / 'actions.db'
+    logger = ActionLogger(str(db_path))
+    for i in range(3):
+        logger.log(f'action{i}', {'id': i})
+
+    recent = logger.get_recent_actions(limit=2)
+    assert len(recent) == 2
+    assert recent[0]['action'] == 'action2'
+    assert recent[1]['action'] == 'action1'
+
+
 def test_scenario_file_cycle(tmp_path):
     dummy = make_dummy(tmp_path)
 


### PR DESCRIPTION
## Summary
- add `get_recent_actions` utility to `ActionLogger`
- test retrieving most recent logged actions

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca6898a808331b645a3a7ea3ef889