### PR TITLE
Update docs for new launch package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,34 @@ The mesh resources are required for accurate visualization in both cases.
 
 2. **Launch the System**
    ```bash
-   ros2 launch simulation_tools integrated_system_launch.py
+   ros2 launch simulation_core full_system.launch.py
    ```
 
    To load a specific scenario or enable advanced perception:
    ```bash
-   ros2 launch simulation_tools integrated_system_launch.py \
+   ros2 launch simulation_core full_system.launch.py \
        scenario:=warehouse use_advanced_perception:=true
    ```
    The `scenario` argument defaults to `default`.
 
    To change the OPC UA server port, pass the `opcua_port` argument:
    ```bash
-  ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+  ros2 launch simulation_core full_system.launch.py opcua_port:=4841
   ```
-  This argument is also supported by `realsense_hybrid_launch.py`.
+   This argument is also supported by `realsense_hybrid_launch.py`.
+
+   ### Run Components Individually
+
+   The main launch file starts everything at once. You can also launch
+   individual components for testing:
+
+   ```bash
+   ros2 launch simulation_core physics_server.launch.py
+   ros2 launch simulation_core environment_manager.launch.py
+   ros2 launch simulation_core web_interface.launch.py
+   ros2 launch simulation_core visualization_server.launch.py
+   ros2 launch simulation_core industrial_bridge.launch.py
+   ```
 
    To secure MQTT communication, configure authentication and TLS in your
    Mosquitto broker. Set the `password_file` option and create a dedicated
@@ -144,21 +157,21 @@ The mesh resources are required for accurate visualization in both cases.
    listens on `127.0.0.1`. If you need to allow remote connections, override the
    `opcua_endpoint` parameter with a host accessible on your network, e.g.:
    ```bash
-   ros2 launch simulation_tools integrated_system_launch.py \
+   ros2 launch simulation_core full_system.launch.py \
        opcua_endpoint:=opc.tcp://0.0.0.0:4840/freeopcua/server/
    ```
 
 ### Configuration Directory and Data Storage
 
 By default, configuration files are loaded from
-`src/simulation_tools/config/`. Pass `config_dir:=<path>` when launching to
+`src/simulation_core/config/`. Pass `config_dir:=<path>` when launching to
 use a custom directory. The `data_dir` parameter controls where log files and
 optional saved images are written (default: `/tmp/simulation_data`).
 
 Example:
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py \
+ros2 launch simulation_core full_system.launch.py \
     config_dir:=/my/configs data_dir:=/tmp/my_data
 ```
 
@@ -178,7 +191,7 @@ detected. You can disable this override by setting the `allow_unsafe_werkzeug`
 parameter to `false`:
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py allow_unsafe_werkzeug:=false
+ros2 launch simulation_core full_system.launch.py allow_unsafe_werkzeug:=false
 ```
 
 Both `web_interface_node` and `visualization_server_node` support a `jpeg_quality`

--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -23,8 +23,19 @@ source install/setup.bash
 Open a terminal and launch the main system (camera simulator, protocol bridge, safety monitor and web server):
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py \
+ros2 launch simulation_core full_system.launch.py \
     use_realsense:=false use_advanced_perception:=true
+```
+
+If you prefer to start components separately for debugging, launch them
+individually:
+
+```bash
+ros2 launch simulation_core physics_server.launch.py
+ros2 launch simulation_core environment_manager.launch.py
+ros2 launch simulation_core web_interface.launch.py
+ros2 launch simulation_core visualization_server.launch.py
+ros2 launch simulation_core industrial_bridge.launch.py
 ```
 
 To begin publishing camera data and metrics, send a start command:

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -45,28 +45,26 @@ The Industrial Robotics Simulation Platform serves as:
 
 The Industrial Robotics Simulation Platform consists of several integrated components:
 
-1. **Camera Simulation**: Provides synthetic RGB and depth image streams simulating industrial cameras
-2. **Environment Configuration**: Manages the simulation environment, objects, and physics
+1. **Physics Server**: Runs the underlying simulation engine and publishes sensor data
+2. **Environment Manager**: Handles environment configuration, objects and physics
 3. **Web Interface**: Provides a user-friendly interface for monitoring and control
 4. **Visualization Server**: Generates visual representations of the simulation state
-5. **Industrial Protocol Bridge**: Connects the simulation to industrial protocols
+5. **Industrial Bridge**: Connects the simulation to industrial protocols
 6. **Safety Monitor**: Enforces safety constraints and monitors for violations
 7. **System Test**: Validates system functionality and integration
 
 ### Architecture Diagram
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  Web Interface  │◄────┤  Environment    │◄────┤  Camera         │
-│  (User Control) │     │  Configuration  │     │  Simulation     │
-└────────┬────────┘     └────────┬────────┘     └─────────────────┘
-         │                       │                       ▲
-         │                       │                       │
-         ▼                       ▼                       │
-┌─────────────────┐     ┌─────────────────┐     ┌───────┴─────────┐
-│  Visualization  │     │  Safety         │     │  Industrial     │
-│  Server         │     │  Monitor        │     │  Protocol Bridge│
-└─────────────────┘     └─────────────────┘     └─────────────────┘
+┌───────────────────┐     ┌────────────────────┐     ┌───────────────────┐
+│  Web Interface    │◄────┤ Environment Manager│◄────┤   Physics Server  │
+└────────┬──────────┘     └──────────┬─────────┘     └──────────▲────────┘
+         │                           │                          │
+         ▼                           ▼                          │
+┌───────────────────┐     ┌──────────────────┐     ┌────────────┴─────────┐
+│ Visualization     │     │  Safety Monitor  │     │  Industrial Bridge   │
+│ Server            │     └──────────────────┘     └──────────────────────┘
+└───────────────────┘
 ```
 
 ### Communication Flow
@@ -254,7 +252,7 @@ The OPC UA server port can also be overridden at launch using the `opcua_port`
 argument. For example:
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+ros2 launch simulation_core full_system.launch.py opcua_port:=4841
 ```
 
 The OPC UA server runs with minimal security configuration and listens only on
@@ -283,13 +281,13 @@ To start the complete system:
 ```bash
 source /opt/ros/humble/setup.bash
 source install/setup.bash
-ros2 launch simulation_tools integrated_system_launch.py
+ros2 launch simulation_core full_system.launch.py
 ```
 
 To launch a specific scenario with advanced perception enabled:
 
 ```bash
-ros2 launch simulation_tools integrated_system_launch.py \
+ros2 launch simulation_core full_system.launch.py \
     scenario:=warehouse use_advanced_perception:=true
 ```
 
@@ -755,7 +753,7 @@ def load_model(self):
 - Verify the configured port is free: `sudo lsof -i:4840`
 - Specify an alternative port when launching, e.g.:
   ```bash
-  ros2 launch simulation_tools integrated_system_launch.py opcua_port:=4841
+  ros2 launch simulation_core full_system.launch.py opcua_port:=4841
   ```
 
 #### MQTT Broker Connection Errors


### PR DESCRIPTION
## Summary
- update README to use `simulation_core` launch files
- show how to start components individually
- update full system run guide with new commands
- refresh deployment guide architecture diagram and commands

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError for 'yaml' and 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684cac8b99448331bbb9f69313cbbfce