### PR TITLE
Add robot description templates

### DIFF
--- a/docs/robot_integration_guide.md
+++ b/docs/robot_integration_guide.md
@@ -1,0 +1,21 @@
+# Robot Integration Guide
+
+This guide outlines the basic steps for adding a new robot to the simulation platform.
+
+## 1. Create a Description Package
+
+1. Start by creating a new package for your robot's URDF/Xacro files.
+2. Copy the templates located in `templates/robot_description` to your package:
+
+```bash
+cp templates/robot_description/template_robot.urdf.xacro <your_pkg>/urdf/
+cp templates/robot_description/template_robot.srdf <your_pkg>/config/
+```
+
+3. Edit the copied files and replace the placeholder comments with your robot's link and joint definitions.
+
+## 2. Update Launch and Configuration Files
+
+After defining the robot, update your launch files and MoveIt configuration to reference the new description files.
+
+Refer to the existing robot packages in `src/` for examples of how everything fits together.

--- a/templates/robot_description/template_robot.srdf
+++ b/templates/robot_description/template_robot.srdf
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<robot name="template_robot">
+    <!--
+        Add planning groups, end effectors and other SRDF entries here.
+        Replace 'template_robot' with your robot's name.
+    -->
+
+    <!-- Example group definition -->
+    <!--
+    <group name="arm">
+        <chain base_link="base_link" tip_link="tool0" />
+    </group>
+    -->
+</robot>

--- a/templates/robot_description/template_robot.urdf.xacro
+++ b/templates/robot_description/template_robot.urdf.xacro
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  Minimal robot description template.
+  Replace 'template_robot' with your robot's name and add link/joint
+  definitions where indicated.
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="template_robot">
+
+  <!-- Insert link elements here -->
+  <!--
+  <link name="base_link">
+    <visual>...</visual>
+  </link>
+  -->
+
+  <!-- Insert joint elements here -->
+  <!--
+  <joint name="joint1" type="revolute">
+    <parent link="base_link" />
+    <child link="link1" />
+    <!-- origin and axis definitions -->
+  </joint>
+  -->
+
+</robot>


### PR DESCRIPTION
## Summary
- add minimal URDF/Xacro and SRDF template files
- document how to use the templates when adding a new robot

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d59238030833193eef907a1246a3c