### PR TITLE
Add robot integration guide and interface docs

### DIFF
--- a/docs/robot_integration_guide.md
+++ b/docs/robot_integration_guide.md
@@ -1,0 +1,15 @@
+# Robot Integration Guide
+
+This guide describes how to connect a new robot implementation to the simulation platform. All robots are expected to communicate with the rest of the system using a set of common ROS2 topics and, where appropriate, services or action interfaces. Following these conventions allows different robot drivers to be swapped without modifying other packages.
+
+## Common ROS2 interfaces
+
+| Interface | Type | Description |
+|-----------|------|-------------|
+| `/robot/command` | `std_msgs/String` | Robot motion or mode commands. Examples include `start`, `stop`, `pick`, and `place`. |
+| `/robot/status` | `std_msgs/String` or `apm_msgs/RobotStatus` | High level status such as `idle`, `running`, or error information. |
+| `/robot/joint_states` | `sensor_msgs/JointState` | Current joint positions reported by the robot. |
+| `/simulation/command` | `std_msgs/String` | Simulation control commands that mirror `/robot/command`. |
+| `/simulation/status` | `std_msgs/String` | Simulation status messages that mirror `/robot/status`. |
+
+Nodes provided in this repository publish and subscribe to the `/simulation/*` topics by default. When integrating a real robot, remap these to the corresponding `/robot/*` interfaces so all other components continue to operate without changes.

--- a/src/apm_msgs/CMakeLists.txt
+++ b/src/apm_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Detection2DArray.msg"
   "msg/DetectedObject.msg"
   "msg/DetectedObjectArray.msg"
+  "msg/RobotStatus.msg"
   DEPENDENCIES std_msgs sensor_msgs geometry_msgs
 )
 

--- a/src/apm_msgs/msg/RobotStatus.msg
+++ b/src/apm_msgs/msg/RobotStatus.msg
@@ -1,0 +1,3 @@
+# Generic robot status information
+string status
+string detail

--- a/src/industrial_protocols/industrial_protocols/industrial_protocol_bridge_node.py
+++ b/src/industrial_protocols/industrial_protocols/industrial_protocol_bridge_node.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+"""
+Bridge ROS2 topics to industrial protocols.
+
+This node expects standard `/robot/command` and `/robot/status` interfaces as described in docs/robot_integration_guide.md.
+"""
 
 import os
 import rclpy

--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+"""
+Web-based interface node for controlling the simulation.
+
+This example follows the standard robot integration interfaces described in docs/robot_integration_guide.md. Commands are published on `/simulation/command` (which can be remapped to `/robot/command`) and status messages are read from `/simulation/status`.
+"""
 
 import os
 import re


### PR DESCRIPTION
## Summary
- document common ROS2 interfaces
- reference `/robot/command` and `/robot/status` in web interface and protocol bridge nodes
- add optional `RobotStatus` message type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d59238c688331b6e9d6e1c2159ced