### PR TITLE
Add jog and waypoint controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ compression (0-100). The default value is `75`.
 Set `auto_open_browser:=true` to automatically open your default web browser
 when the interface starts. This is disabled by default for headless systems.
 
+### Robot Jogging and Waypoint Control
+
+The control panel exposes sliders to jog each joint and buttons to record
+waypoints. Recorded poses can be cleared or executed as a sequence. A typical
+workflow is:
+
+1. Jog the robot to a desired pose using the **Jog Joints** sliders.
+2. Click **Record Waypoint** to store the position.
+3. Repeat to add more waypoints.
+4. Press **Execute Sequence** to move the robot through the recorded poses.
+
 ## Documentation
 
 For complete details, please refer to the included `industrial_deployment_guide.md` which provides comprehensive instructions for:

--- a/src/simulation_core/simulation_core/__init__.py
+++ b/src/simulation_core/simulation_core/__init__.py
@@ -1,0 +1,3 @@
+from .robot_control_node import RobotControlNode
+
+__all__ = ["RobotControlNode"]

--- a/src/simulation_core/simulation_core/robot_control_node.py
+++ b/src/simulation_core/simulation_core/robot_control_node.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+class RobotControlNode(Node):
+    """Translate high level commands into robot specific topics."""
+
+    def __init__(self):
+        super().__init__('robot_control_node')
+
+        self.declare_parameter('jog_topic', '/robot/jog')
+        self.declare_parameter('waypoint_topic', '/robot/waypoint')
+        self.declare_parameter('sequence_topic', '/robot/execute_sequence')
+
+        self.jog_topic = self.get_parameter('jog_topic').value
+        self.waypoint_topic = self.get_parameter('waypoint_topic').value
+        self.sequence_topic = self.get_parameter('sequence_topic').value
+
+        self.jog_pub = self.create_publisher(String, self.jog_topic, 10)
+        self.waypoint_pub = self.create_publisher(String, self.waypoint_topic, 10)
+        self.sequence_pub = self.create_publisher(String, self.sequence_topic, 10)
+
+        self.command_sub = self.create_subscription(
+            String,
+            '/simulation/command',
+            self.command_callback,
+            10,
+        )
+
+        self.get_logger().info('Robot control node initialized')
+
+    def command_callback(self, msg: String):
+        parts = msg.data.split()
+        if not parts:
+            return
+
+        cmd = parts[0]
+        if cmd == 'jog' and len(parts) == 3:
+            out = String()
+            out.data = f"{parts[1]} {parts[2]}"
+            self.jog_pub.publish(out)
+        elif cmd in ('record_waypoint', 'clear_waypoints'):
+            out = String()
+            out.data = cmd
+            self.waypoint_pub.publish(out)
+        elif cmd == 'execute_sequence':
+            out = String()
+            out.data = 'execute'
+            self.sequence_pub.publish(out)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = RobotControlNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/web_interface_frontend/templates/control.html
+++ b/src/web_interface_frontend/templates/control.html
@@ -82,6 +82,30 @@
         </div>
         <div class="card">
             <div class="card-header">
+                <h5 class="card-title">Jog Joints</h5>
+            </div>
+            <div class="card-body">
+                {% for i in range(6) %}
+                <div class="input-group mb-2">
+                    <span class="input-group-text">J{{i}}</span>
+                    <input type="range" min="-0.5" max="0.5" step="0.05" value="0" class="form-range jog-slider" data-joint="{{i}}">
+                    <button class="btn btn-outline-secondary jog-btn">Jog</button>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title">Waypoints</h5>
+            </div>
+            <div class="card-body d-grid gap-2">
+                <button id="record-waypoint" class="btn btn-outline-primary">Record Waypoint</button>
+                <button id="clear-waypoints" class="btn btn-outline-warning">Clear Waypoints</button>
+                <button id="execute-sequence" class="btn btn-outline-success">Execute Sequence</button>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header">
                 <h5 class="card-title">Recording & Playback</h5>
             </div>
             <div class="card-body d-grid gap-2">
@@ -163,6 +187,11 @@ const startPlayBtn = document.getElementById('start-play');
 const stopPlayBtn = document.getElementById('stop-play');
 const exportToggle = document.getElementById('export-toggle');
 const exportList = document.getElementById('export-list');
+const jogSliders = document.querySelectorAll('.jog-slider');
+const jogButtons = document.querySelectorAll('.jog-btn');
+const recordWaypointBtn = document.getElementById('record-waypoint');
+const clearWaypointsBtn = document.getElementById('clear-waypoints');
+const executeSequenceBtn = document.getElementById('execute-sequence');
 const ctx = workspaceCanvas.getContext('2d');
 let objects = [];
 let scene, camera, renderer;
@@ -385,6 +414,21 @@ placeCustomBtn.addEventListener('click', function() {
     .then(data => { if (data.success) { addToCommandLog(`Sent place command for location (${x}, ${y}, ${z})`); } else { addToCommandLog(`Error: ${data.error}`); } })
     .catch(error => { console.error('Error:', error); addToCommandLog('Error sending place command'); });
 });
+jogButtons.forEach((btn, idx) => {
+    btn.addEventListener('click', () => {
+        const slider = jogSliders[idx];
+        const joint = parseInt(slider.dataset.joint);
+        const delta = parseFloat(slider.value);
+        fetch('/api/jog', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ joint: joint, delta: delta })
+        }).then(() => addToCommandLog(`Jog joint ${joint} by ${delta}`));
+    });
+});
+recordWaypointBtn.addEventListener('click', () => sendWaypoint('record'));
+clearWaypointsBtn.addEventListener('click', () => sendWaypoint('clear'));
+executeSequenceBtn.addEventListener('click', () => sendWaypoint('execute'));
 startRecBtn.addEventListener('click', () => sendCommand('start_recording'));
 stopRecBtn.addEventListener('click', () => sendCommand('stop_recording'));
 startPlayBtn.addEventListener('click', () => sendCommand('start_playback'));
@@ -404,6 +448,13 @@ function loadExports() {
                 exportList.appendChild(li);
             });
         });
+}
+function sendWaypoint(action) {
+    fetch('/api/waypoint', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: action })
+    }).then(() => addToCommandLog('Waypoint: ' + action));
 }
 function sendCommand(cmd) {
     fetch('/api/command', {

--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -207,3 +207,49 @@ def test_objects_api_returns_latest(monkeypatch):
     res = client.get('/api/objects')
     assert res.status_code == 200
     assert res.json['objects'][0]['id'] == 1
+
+
+def test_jog_api_publishes(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    logger_mock = MagicMock()
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock(return_value=logger_mock))
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+
+    res = client.post('/api/jog', json={'joint': 1, 'delta': 0.1})
+    assert res.status_code == 200
+    msg = node.command_pub.publish.call_args[0][0]
+    assert msg.data == 'jog 1 0.1'
+    logger_mock.log.assert_called_once_with('jog', {'joint': 1, 'delta': 0.1})
+
+
+def test_waypoint_api_execute(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    logger_mock = MagicMock()
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock(return_value=logger_mock))
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+
+    res = client.post('/api/waypoint', json={'action': 'execute'})
+    assert res.status_code == 200
+    msg = node.command_pub.publish.call_args[0][0]
+    assert msg.data == 'execute_sequence'
+    logger_mock.log.assert_called_once_with('waypoint', {'action': 'execute'})


### PR DESCRIPTION
## Summary
- add REST & socket events for jogging joints and waypoint sequence control
- extend control panel with sliders & buttons
- implement RobotControlNode to translate commands to robot topics
- document new workflow
- test jogging and waypoint API endpoints

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d59cbb8a483319b54f060d1935775