### PR TITLE
Fix blank line spacing in web interface API tests

### DIFF
--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -79,6 +79,7 @@ def _setup_ros_stubs(monkeypatch):
     sensor_stub = types.ModuleType('sensor_msgs')
     sensor_stub.msg = types.ModuleType('sensor_msgs.msg')
     sensor_stub.msg.Image = Msg
+
     class JS:
         def __init__(self):
             self.name = []
@@ -246,6 +247,7 @@ def test_joint_state_emits_socket_event(monkeypatch):
         'velocity': [0.5],
     })
 
+
 def test_jog_api_publishes(monkeypatch):
     _setup_ros_stubs(monkeypatch)
 
@@ -267,6 +269,7 @@ def test_jog_api_publishes(monkeypatch):
     msg = node.command_pub.publish.call_args[0][0]
     assert msg.data == 'jog 1 0.1'
     logger_mock.log.assert_called_once_with('jog', {'joint': 1, 'delta': 0.1})
+
 
 def test_waypoint_api_execute(monkeypatch):
     _setup_ros_stubs(monkeypatch)
@@ -290,6 +293,7 @@ def test_waypoint_api_execute(monkeypatch):
     assert msg.data == 'execute_sequence'
     logger_mock.log.assert_called_once_with('waypoint', {'action': 'execute'})
 
+
 def test_load_scenario_endpoint(monkeypatch):
     _setup_ros_stubs(monkeypatch)
 
@@ -312,6 +316,7 @@ def test_load_scenario_endpoint(monkeypatch):
     msg = node.config_pub.publish.call_args[0][0]
     assert json.loads(msg.data) == {'scenario': 'foo'}
     logger_mock.log.assert_called_once_with('load_scenario', {'id': 'foo'})
+
 
 def test_save_scenario_endpoint(monkeypatch, tmp_path):
     _setup_ros_stubs(monkeypatch)
@@ -342,4 +347,3 @@ def test_save_scenario_endpoint(monkeypatch, tmp_path):
     data = json.loads(msg.data)
     assert data['update_scenario']['name'] == 'test'
     logger_mock.log.assert_called_with('save_scenario', {'id': 'test'})
-


### PR DESCRIPTION
## Summary
- add missing blank line before `JS` class
- ensure two blank lines separate top-level test functions
- remove trailing blank line at file end

## Testing
- `flake8 tests/test_web_interface_api.py`

------
https://chatgpt.com/codex/tasks/task_e_684d74610798833182175f54ee8a9373