### PR TITLE
Fix fy computation in synthetic camera

### DIFF
--- a/src/perception_nodes/perception_nodes/synthetic_camera_node.py
+++ b/src/perception_nodes/perception_nodes/synthetic_camera_node.py
@@ -334,8 +334,8 @@ class CameraSimulatorNode(Node):
         camera_info.height = self.height
 
         # Set camera matrix (intrinsics)
-        fx = self.width * 0.8  # focal length x
-        fy = self.width * 0.8  # focal length y
+        fx = self.width * 0.8   # focal length x
+        fy = self.height * 0.8  # focal length y
         cx = self.width / 2    # optical center x
         cy = self.height / 2   # optical center y
 


### PR DESCRIPTION
## Summary
- adjust `fy` computation to use image height

## Testing
- `flake8 src tests` *(fails: blank lines and formatting issues)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d74772cdc8331bf1203157d5320c1