### PR TITLE
Refactor api_actions to use ActionLogger method

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -588,20 +588,7 @@ class WebInterfaceNode(Node):
             limit = int(request.args.get('limit', 100))
             rows = []
             try:
-                with self.action_logger._lock:
-                    cur = self.action_logger._conn.execute(
-                        "SELECT timestamp, action, details FROM actions "
-                        "ORDER BY id DESC LIMIT ?",
-                        (limit,),
-                    )
-                    rows = [
-                        {
-                            'timestamp': r[0],
-                            'action': r[1],
-                            'details': r[2],
-                        }
-                        for r in cur.fetchall()
-                    ]
+                rows = self.action_logger.get_recent_actions(limit)
             except Exception as e:
                 self.get_logger().error(f'Error reading actions: {e}')
             return jsonify({'actions': rows})


### PR DESCRIPTION
## Summary
- refactor `/api/actions` endpoint to fetch entries via `ActionLogger.get_recent_actions`

## Testing
- `flake8 src tests` *(fails: W391/E306/E302)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d747fc65883319f9f4222feb4fcf4