### PR TITLE
Centralize run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,132 +96,14 @@ The mesh resources are required for accurate visualization in both cases.
 
 ## Getting Started
 
-1. **Installation**
-   ```bash
-   source /opt/ros/humble/setup.bash
-   cd industrial_robotics_simulation_platform
-   pip install -r requirements.txt
-   sudo apt install python3-rosdep
-   sudo rosdep init
-   rosdep update
-   rosdep install --from-paths src -y --ignore-src
-   colcon build --symlink-install
-   source install/setup.bash
-   ```
-   The `rosdep` commands resolve additional ROS packages required for the workspace.
-
-2. **Launch the System**
-   ```bash
-   ros2 launch simulation_core full_system.launch.py
-   ```
-
-   To load a specific scenario or enable advanced perception:
-   ```bash
-   ros2 launch simulation_core full_system.launch.py \
-       scenario:=warehouse use_advanced_perception:=true
-   ```
-   The `scenario` argument defaults to `default`.
-
-   To change the OPC UA server port, pass the `opcua_port` argument:
-   ```bash
-  ros2 launch simulation_core full_system.launch.py opcua_port:=4841
-  ```
-   This argument is also supported by `realsense_hybrid_launch.py`.
-
-   ### Run Components Individually
-
-   The main launch file starts everything at once. You can also launch
-   individual components for testing:
-
-   ```bash
-   ros2 launch simulation_core physics_server.launch.py
-   ros2 launch simulation_core environment_manager.launch.py
-   ros2 launch simulation_core web_interface.launch.py
-   ros2 launch simulation_core visualization_server.launch.py
-   ros2 launch simulation_core industrial_bridge.launch.py
-   ```
-
-   To secure MQTT communication, configure authentication and TLS in your
-   Mosquitto broker. Set the `password_file` option and create a dedicated
-   listener for TLS traffic:
-   ```
-   listener 8883
-   password_file /etc/mosquitto/passwd
-   cafile /etc/mosquitto/ca.crt
-   certfile /etc/mosquitto/server.crt
-   keyfile /etc/mosquitto/server.key
-   allow_anonymous false
-   ```
-   Refer to the [Mosquitto security documentation](https://mosquitto.org/man/mosquitto-conf-5.html) for details.
-
-   The industrial protocol bridge expects a local MQTT broker. Install and start
-   Mosquitto with:
-
-   ```bash
-   sudo apt install mosquitto
-   sudo systemctl start mosquitto
-   ```
-
-   Launch with `mqtt_enabled:=false` if a broker is not available.
-
-   The OPC UA server is configured with minimal security and, by default, only
-   listens on `127.0.0.1`. If you need to allow remote connections, override the
-   `opcua_endpoint` parameter with a host accessible on your network, e.g.:
-   ```bash
-   ros2 launch simulation_core full_system.launch.py \
-       opcua_endpoint:=opc.tcp://0.0.0.0:4840/freeopcua/server/
-   ```
-
-### Configuration Directory and Data Storage
-
-By default, configuration files are loaded from
-`src/simulation_core/config/`. Pass `config_dir:=<path>` when launching to
-use a custom directory. The `data_dir` parameter controls where log files and
-optional saved images are written (default: `/tmp/simulation_data`).
-
-Example:
+For complete installation and launch instructions see
+[docs/full_system_run_guide.md](docs/full_system_run_guide.md). After installing
+the required dependencies and building the workspace, start the full system
+with:
 
 ```bash
-ros2 launch simulation_core full_system.launch.py \
-    config_dir:=/my/configs data_dir:=/tmp/my_data
+ros2 launch simulation_core full_system.launch.py
 ```
-
-Scenario YAML files such as `pick_and_place.yaml` can be duplicated and
-modified in your custom directory to define new scenarios.
-
-3. **Access the Web Interface**
-   ```
-   http://localhost:8080
-   ```
-
-### Web Interface Configuration
-
-The web server uses Flask's development server via `socketio.run`. By default,
-the system allows Werkzeug to run even if a production environment is
-detected. You can disable this override by setting the `allow_unsafe_werkzeug`
-parameter to `false`:
-
-```bash
-ros2 launch simulation_core full_system.launch.py allow_unsafe_werkzeug:=false
-```
-
-Both nodes in the `web_interface_backend` package, `web_interface_node` and
-`visualization_server_node`, support a `jpeg_quality` parameter to control JPEG
-compression (0-100). The default value is `75`.
-
-Set `auto_open_browser:=true` to automatically open your default web browser
-when the interface starts. This is disabled by default for headless systems.
-
-### Robot Jogging and Waypoint Control
-
-The control panel exposes sliders to jog each joint and buttons to record
-waypoints. Recorded poses can be cleared or executed as a sequence. A typical
-workflow is:
-
-1. Jog the robot to a desired pose using the **Jog Joints** sliders.
-2. Click **Record Waypoint** to store the position.
-3. Repeat to add more waypoints.
-4. Press **Execute Sequence** to move the robot through the recorded poses.
 
 ## Documentation
 

--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -4,15 +4,18 @@ This guide walks through launching every component of the simulation platform: G
 
 ## Prerequisites
 
-- ROS 2 Humble installed and sourced (`source /opt/ros/humble/setup.bash`)
-- The workspace built as described in the main README
+- Ubuntu 22.04 or newer with ROS&nbsp;2 Humble installed (`source /opt/ros/humble/setup.bash`)
 - Gazebo packages installed (`sudo apt install ros-humble-gazebo-ros-pkgs`)
+- `python3-rosdep` installed and initialized
 
 ## 1. Build the Workspace
 
 ```bash
 cd industrial_robotics_simulation_platform
 pip install -r requirements.txt
+sudo apt install python3-rosdep
+sudo rosdep init
+rosdep update
 rosdep install --from-paths src -y --ignore-src
 colcon build --symlink-install
 source install/setup.bash

--- a/industrial_deployment_guide.md
+++ b/industrial_deployment_guide.md
@@ -94,68 +94,9 @@ The system uses ROS2 topics for inter-component communication:
 
 ## Installation
 
-### Prerequisites
-
-- Ubuntu 22.04 or newer
-- ROS2 Humble or newer
-- Python 3.8 or newer
-- Web browser (Chrome, Firefox, or Edge recommended)
-
-### Dependencies
-
-```bash
-# Install ROS2 dependencies
-sudo apt update
-sudo apt install -y python3-pip python3-opencv python3-yaml python3-matplotlib
-sudo apt install -y ros-humble-cv-bridge ros-humble-sensor-msgs
-
-# Install Python dependencies
-pip3 install flask flask-socketio rclpy numpy opencv-python pyyaml matplotlib
-pip3 install asyncua paho-mqtt  # For industrial protocol support
-```
-
-### UR5 Mesh Assets
-
-The UR5 meshes are provided by the `ur_description` package for your ROS 2
-distribution. Install this package using apt so that the URDF can locate the
-meshes:
-
-```bash
-sudo apt-get install ros-<distro>-ur-description
-```
-
-The meshes will then reside under
-`/opt/ros/<distro>/share/ur_description/meshes`. If you built the package from
-source or installed it to a custom location, ensure that directory is included
-in your `ROS_PACKAGE_PATH` or create a symlink to
-`src/ur5_robot_description/meshes`.
-
-After installing dependencies and the package, build the workspace:
-
-```bash
-source /opt/ros/humble/setup.bash
-colcon build --symlink-install
-source install/setup.bash
-```
-
-### Building the Workspace
-
-1. Clone the repository:
-```bash
-git clone https://github.com/your-organization/industrial_robotics_simulation_platform.git
-cd industrial_robotics_simulation_platform
-```
-
-2. Build the workspace:
-```bash
-source /opt/ros/humble/setup.bash
-colcon build --symlink-install
-```
-
-3. Source the workspace:
-```bash
-source install/setup.bash
-```
+Detailed installation steps, including dependency setup and workspace building,
+are provided in
+[docs/full_system_run_guide.md](docs/full_system_run_guide.md).
 
 ## Configuration
 
@@ -285,28 +226,10 @@ See the [Mosquitto documentation](https://mosquitto.org/man/mosquitto-conf-5.htm
 
 ### Starting the System
 
-To start the complete system:
-
-```bash
-source /opt/ros/humble/setup.bash
-source install/setup.bash
-ros2 launch simulation_core full_system.launch.py
-```
-
-To launch a specific scenario with advanced perception enabled:
-
-```bash
-ros2 launch simulation_core full_system.launch.py \
-    scenario:=warehouse use_advanced_perception:=true
-```
-
-### Accessing the Web Interface
-
-Once the system is running, access the web interface at:
-
-```
-http://localhost:8080
-```
+Follow the steps in
+[docs/full_system_run_guide.md](docs/full_system_run_guide.md) to build and
+launch the full system. Once running, open `http://localhost:8080` to access the
+web interface.
 
 ### Basic Commands
 


### PR DESCRIPTION
## Summary
- consolidate full build & launch steps into docs/full_system_run_guide.md
- shorten README getting started section to link to the guide
- point industrial_deployment_guide to the same guide

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850749734288331a9412cb8ae121dd7