### PR TITLE
Ensure ActionLogger creates directories

### DIFF
--- a/src/web_interface_backend/web_interface_backend/action_logger.py
+++ b/src/web_interface_backend/web_interface_backend/action_logger.py
@@ -3,6 +3,7 @@ import sqlite3
 import time
 import json
 import logging
+import os
 from threading import Lock
 
 class ActionLogger:
@@ -13,6 +14,11 @@ class ActionLogger:
         self.db_path = db_path
         self.raise_errors = raise_errors
         self._lock = Lock()
+
+        dir_name = os.path.dirname(self.db_path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
+
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._initialize()
 

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -105,6 +105,15 @@ def test_action_logger_get_recent(tmp_path):
     assert recent[1]['action'] == 'action1'
 
 
+def test_action_logger_creates_dir(tmp_path):
+    db_path = tmp_path / 'logs' / 'actions' / 'actions.db'
+    logger = ActionLogger(str(db_path))
+    assert db_path.parent.exists()
+    logger.log('test')
+    logger.close()
+    assert db_path.exists()
+
+
 def test_scenario_file_cycle(tmp_path):
     dummy = make_dummy(tmp_path)
 


### PR DESCRIPTION
## Summary
- create parent directory before connecting SQLite DB
- test ActionLogger directory creation

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685182b43af0833190c3746b652b7fab