### PR TITLE
Add Dockerfile for ROS 2 system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ros:humble-ros-base
+
+# Create workspace
+WORKDIR /opt/industrial_ws
+
+# Copy repository contents
+COPY . /opt/industrial_ws
+
+# Install system dependencies and Python requirements
+RUN apt-get update && \
+    rosdep update && \
+    rosdep install --from-paths src -y --ignore-src && \
+    pip install --no-cache-dir -r requirements.txt && \
+    . /opt/ros/humble/setup.sh && \
+    colcon build
+
+# Default command runs the integrated launch file
+CMD bash -c "source /opt/ros/humble/setup.bash && source install/setup.bash && ros2 launch simulation_tools integrated_system_launch.py"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ git lfs track "*.onnx" "*.tar.gz" "*.ckpt"
 git add .gitattributes
 ```
 
+## Docker Usage
+
+Build the image from the repository root:
+
+```bash
+docker build -t industrial_sim .
+```
+
+Run the container with host networking so ROS 2 topics are visible:
+
+```bash
+docker run --rm -it --net=host industrial_sim
+```
+
+The container will automatically launch the integrated system using
+`simulation_tools/integrated_system_launch.py`.
+
 ## Running Tests
 
 `pytest` is used for running the unit tests. After building the workspace,


### PR DESCRIPTION
## Summary
- add a Dockerfile using `ros:humble-ros-base`
- describe how to build and run the container in the README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851899dd5588331ab878c6504217719