### PR TITLE
Add tests for segmentation and pose estimation nodes

### DIFF
--- a/tests/test_pose_estimation_node_module.py
+++ b/tests/test_pose_estimation_node_module.py
@@ -1,0 +1,134 @@
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+from test_utils import _setup_ros_stubs
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'src' / 'advanced_perception'))
+
+
+def _setup_apm(monkeypatch):
+    apm = types.ModuleType('apm_msgs')
+    apm.msg = types.ModuleType('apm_msgs.msg')
+
+    class Detection2D:
+        def __init__(self):
+            self.class_id = 0
+            self.class_name = ''
+            self.score = 0.0
+            self.bbox = types.SimpleNamespace(
+                x_offset=0, y_offset=0, width=0, height=0, do_rectify=False
+            )
+
+    class Detection2DArray:
+        def __init__(self):
+            self.header = None
+            self.detections = []
+
+    class Pose:
+        def __init__(self):
+            self.position = types.SimpleNamespace(x=0.0, y=0.0, z=0.0)
+            self.orientation = types.SimpleNamespace(w=1.0, x=0.0, y=0.0, z=0.0)
+
+    class Dimensions:
+        def __init__(self):
+            self.x = 0.0
+            self.y = 0.0
+            self.z = 0.0
+
+    class DetectedObject:
+        def __init__(self):
+            self.header = None
+            self.id = 0
+            self.class_id = 0
+            self.class_name = ''
+            self.confidence = 0.0
+            self.pose = Pose()
+            self.dimensions = Dimensions()
+
+    class DetectedObjectArray:
+        def __init__(self):
+            self.header = None
+            self.objects = []
+
+    apm.msg.Detection2D = Detection2D
+    apm.msg.Detection2DArray = Detection2DArray
+    apm.msg.DetectedObject = DetectedObject
+    apm.msg.DetectedObjectArray = DetectedObjectArray
+    monkeypatch.setitem(sys.modules, 'apm_msgs', apm)
+    monkeypatch.setitem(sys.modules, 'apm_msgs.msg', apm.msg)
+
+
+class DummyBridge:
+    def imgmsg_to_cv2(self, *a, **k):
+        return np.zeros((4, 4), dtype=np.uint16)
+
+
+def _setup_bridge(monkeypatch):
+    import cv_bridge
+
+    monkeypatch.setattr(cv_bridge, 'CvBridge', DummyBridge, raising=False)
+
+
+def test_load_config_defaults(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.pose_estimation_node', None)
+    from advanced_perception import pose_estimation_node as pn
+
+    node = pn.PoseEstimationNode()
+    assert node.min_depth == 0.1
+    assert node.max_depth == 5.0
+    assert node.depth_scale == 0.001
+
+
+def test_load_config_file(monkeypatch, tmp_path):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.pose_estimation_node', None)
+    from advanced_perception import pose_estimation_node as pn
+
+    cfg = tmp_path / 'pose.yaml'
+    cfg.write_text('min_depth: 0.5\nmax_depth: 2.0\ndepth_scale: 0.002\n')
+
+    node = pn.PoseEstimationNode()
+    node.pose_estimation_config_path = str(cfg)
+    node.load_config()
+
+    assert node.min_depth == 0.5
+    assert node.max_depth == 2.0
+    assert node.depth_scale == 0.002
+
+
+def test_process_data_publishes(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.pose_estimation_node', None)
+    from advanced_perception import pose_estimation_node as pn
+    import apm_msgs.msg as msg
+
+    node = pn.PoseEstimationNode()
+    node.camera_matrix = np.eye(3)
+    node.latest_rgb_image = np.zeros((4, 4, 3), dtype=np.uint8)
+    node.latest_depth_image = np.ones((4, 4), dtype=np.uint16) * 1000
+
+    det = msg.Detection2D()
+    det.bbox.width = 2
+    det.bbox.height = 2
+    det_array = msg.Detection2DArray()
+    det_array.detections = [det]
+    det_array.header = object()
+    node.latest_segmented_objects = det_array
+
+    node.objects_pub.publish.reset_mock()
+    node.process_data()
+
+    assert node.objects_pub.publish.called
+    out = node.objects_pub.publish.call_args[0][0]
+    assert len(out.objects) == 1

--- a/tests/test_segmentation_node_module.py
+++ b/tests/test_segmentation_node_module.py
@@ -1,0 +1,111 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from test_utils import _setup_ros_stubs
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'src' / 'advanced_perception'))
+
+
+def _setup_apm(monkeypatch):
+    apm = types.ModuleType('apm_msgs')
+    apm.msg = types.ModuleType('apm_msgs.msg')
+
+    class Detection2D:
+        def __init__(self):
+            self.class_id = 0
+            self.class_name = ''
+            self.score = 0.0
+            self.bbox = types.SimpleNamespace(
+                x_offset=0, y_offset=0, width=0, height=0, do_rectify=False
+            )
+
+    class Detection2DArray:
+        def __init__(self):
+            self.header = None
+            self.detections = []
+
+    apm.msg.Detection2D = Detection2D
+    apm.msg.Detection2DArray = Detection2DArray
+    monkeypatch.setitem(sys.modules, 'apm_msgs', apm)
+    monkeypatch.setitem(sys.modules, 'apm_msgs.msg', apm.msg)
+
+
+class DummyBridge:
+    def imgmsg_to_cv2(self, *a, **k):
+        return np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def cv2_to_imgmsg(self, *a, **k):
+        return types.SimpleNamespace(header=None)
+
+
+def _setup_bridge(monkeypatch):
+    import cv_bridge
+
+    monkeypatch.setattr(cv_bridge, 'CvBridge', DummyBridge, raising=False)
+
+    exec_mod = types.ModuleType('rclpy.executors')
+    exec_mod.MultiThreadedExecutor = MagicMock()
+    monkeypatch.setitem(sys.modules, 'rclpy.executors', exec_mod)
+
+
+def test_load_config_defaults(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.segmentation_node', None)
+    from advanced_perception import segmentation_node as sn
+
+    node = sn.SegmentationNode()
+    assert np.array_equal(node.threshold_min, np.array([0, 0, 0]))
+    assert np.array_equal(node.threshold_max, np.array([255, 255, 255]))
+    assert node.min_contour_area == 1000
+
+
+def test_load_config_file(monkeypatch, tmp_path):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.segmentation_node', None)
+    from advanced_perception import segmentation_node as sn
+
+    cfg = tmp_path / 'seg.yaml'
+    cfg.write_text(
+        'threshold_min: [1, 2, 3]\nthreshold_max: [4, 5, 6]\nmin_contour_area: 50\n'
+    )
+
+    node = sn.SegmentationNode()
+    node.segmentation_config_path = str(cfg)
+    node.load_config()
+
+    assert node.min_contour_area == 50
+    assert node.threshold_min.tolist() == [1, 2, 3]
+    assert node.threshold_max.tolist() == [4, 5, 6]
+
+
+def test_process_image_publishes(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    _setup_apm(monkeypatch)
+    _setup_bridge(monkeypatch)
+    sys.modules.pop('advanced_perception.segmentation_node', None)
+    from advanced_perception import segmentation_node as sn
+
+    node = sn.SegmentationNode()
+    det = sys.modules['apm_msgs'].msg.Detection2D()
+
+    def fake_segment(image):
+        return image, [det]
+
+    monkeypatch.setattr(node, 'segment_image', fake_segment)
+
+    msg = types.SimpleNamespace(header=object())
+    node.process_image(msg)
+
+    assert node.segmented_image_pub.publish.called
+    assert node.segmented_objects_pub.publish.called
+    out = node.segmented_objects_pub.publish.call_args[0][0]
+    assert len(out.detections) == 1


### PR DESCRIPTION
## Summary
- add tests for segmentation_node.py covering config loading and image processing
- add tests for pose_estimation_node.py covering config loading and data processing

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685189cbe6f48331a43c2a23797863d2