### PR TITLE
Ensure scenario directory is created

### DIFF
--- a/src/simulation_core/simulation_core/environment_configurator_node.py
+++ b/src/simulation_core/simulation_core/environment_configurator_node.py
@@ -237,7 +237,9 @@ class EnvironmentConfiguratorNode(Node):
         if not self.config_dir:
             self.get_logger().error('Config directory not set, cannot save scenario')
             return
-        
+
+        os.makedirs(self.config_dir, exist_ok=True)
+
         scenario_id = scenario_data.get('name', 'custom')
         description = scenario_data.get('description', 'Custom scenario')
         config = scenario_data.get('config', {})

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -130,6 +130,17 @@ def test_scenario_file_cycle(tmp_path):
     assert not path.exists()
 
 
+def test_save_scenario_creates_dir(tmp_path):
+    config_dir = tmp_path / 'configs' / 'scenarios'
+    dummy = make_dummy(config_dir)
+
+    data = {'name': 'auto', 'config': {}}
+    ec.EnvironmentConfiguratorNode.save_scenario(dummy, data)
+
+    assert config_dir.exists()
+    assert (config_dir / 'auto.yaml').exists()
+
+
 def test_update_settings(tmp_path):
     dummy = make_dummy(tmp_path)
     ec.EnvironmentConfiguratorNode.update_settings(


### PR DESCRIPTION
## Summary
- create config directory when saving scenarios
- add test ensuring save_scenario creates directory automatically

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518b3a88408331a47fe53b95bc6a41