### PR TITLE
Add test usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For complete details, please refer to the included `industrial_deployment_guide.
 - API reference
 - Step-by-step instructions for running the full system: [docs/full_system_run_guide.md](docs/full_system_run_guide.md)
 - Guide for integrating new robots: [docs/robot_integration_guide.md](docs/robot_integration_guide.md)
+- Guide for running the test suite: [docs/testing_guide.md](docs/testing_guide.md)
 
 ## Commercial Applications
 

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -1,0 +1,45 @@
+# Testing Guide
+
+This guide explains how to run the automated tests and style checks for the Industrial Robotics Simulation Platform.
+
+## 1. Install Dependencies
+
+Install the Python packages listed in `requirements.txt` along with the development tools:
+
+```bash
+pip install -r requirements.txt
+pip install flake8 pytest
+```
+
+The tests use stub modules so ROS&nbsp;2 is not required. Ensure all dependencies are available in your environment before running the suite.
+
+## 2. Run Flake8
+
+Check code formatting with `flake8`:
+
+```bash
+flake8 src tests
+```
+
+## 3. Execute the Tests
+
+Run all unit tests from the repository root:
+
+```bash
+pytest
+```
+
+Individual tests can be executed by passing a file path, for example:
+
+```bash
+pytest tests/test_core_logic.py
+```
+
+## 4. Test Structure
+
+All test cases live in the `tests/` directory. Each file targets a specific package or ROS&nbsp;2 node and uses lightweight stubs so the suite can run without a full ROS installation.
+
+When adding new features, place the corresponding tests in this folder and keep them independent of ROS whenever possible.
+
+
+For additional details see the "Running Tests" section in the project README.


### PR DESCRIPTION
## Summary
- document how to run automated tests in `docs/testing_guide.md`
- link to the new guide from the main README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518b9141988331acc0b6f3ed1337d7