### PR TITLE
Add 3D Matplotlib viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The ROS workspace is organized into modular packages:
 - `web_interface_frontend` – static HTML/JS resources
    - Performance metrics dashboard
    - 3D environment visualization
+   - Matplotlib-based 3D object viewer
    - Live plots for joint angles and sensors
 
 4. **Industrial Integration**

--- a/src/simulation_tools/setup.py
+++ b/src/simulation_tools/setup.py
@@ -20,5 +20,9 @@ setup(
     maintainer_email='user@example.com',
     description='Industrial Robotics Simulation Tools',
     license='Apache-2.0',
-    entry_points={'console_scripts': []},
+    entry_points={
+        'console_scripts': [
+            'object_3d_viewer = simulation_tools.object_3d_viewer_node:main',
+        ]
+    },
 )

--- a/src/simulation_tools/simulation_tools/__init__.py
+++ b/src/simulation_tools/simulation_tools/__init__.py
@@ -1,3 +1,5 @@
-"""Legacy package retaining launch files."""
+"""Utility nodes for simulation tools."""
 
-__all__ = []
+__all__ = ['Object3DViewerNode']
+
+from .object_3d_viewer_node import Object3DViewerNode

--- a/src/simulation_tools/simulation_tools/object_3d_viewer_node.py
+++ b/src/simulation_tools/simulation_tools/object_3d_viewer_node.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""ROS2 node visualizing detected objects in 3D using Matplotlib."""
+
+import threading
+
+import rclpy
+from rclpy.node import Node
+from matplotlib import pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+from apm_msgs.msg import DetectedObjectArray
+
+
+class Object3DViewerNode(Node):
+    """Display DetectedObjectArray messages using Matplotlib."""
+
+    def __init__(self) -> None:
+        super().__init__('object_3d_viewer_node')
+
+        self.declare_parameter('objects_topic', '/apm/detection/objects')
+        self.objects_topic = self.get_parameter('objects_topic').value
+
+        self.objects_sub = self.create_subscription(
+            DetectedObjectArray,
+            self.objects_topic,
+            self.objects_callback,
+            10,
+        )
+
+        self.objects = []
+        self.lock = threading.Lock()
+
+        plt.ion()
+        self.fig = plt.figure()
+        self.ax = self.fig.add_subplot(111, projection='3d')
+        self.timer = self.create_timer(0.5, self.update_plot)
+
+        self.get_logger().info('Object 3D viewer node initialized')
+
+    def objects_callback(self, msg: DetectedObjectArray) -> None:
+        """Store latest object positions."""
+        positions = [
+            (obj.pose.position.x, obj.pose.position.y, obj.pose.position.z)
+            for obj in msg.objects
+        ]
+        with self.lock:
+            self.objects = positions
+
+    def update_plot(self) -> None:
+        """Refresh Matplotlib scatter plot."""
+        with self.lock:
+            xs = [p[0] for p in self.objects]
+            ys = [p[1] for p in self.objects]
+            zs = [p[2] for p in self.objects]
+        self.ax.clear()
+        if xs:
+            self.ax.scatter(xs, ys, zs, c='r', marker='o')
+        self.ax.set_xlabel('X (m)')
+        self.ax.set_ylabel('Y (m)')
+        self.ax.set_zlabel('Z (m)')
+        self.ax.set_title('Detected Objects')
+        self.fig.canvas.draw()
+        self.fig.canvas.flush_events()
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = Object3DViewerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `Object3DViewerNode` for Matplotlib-based visualization
- expose the node via `object_3d_viewer` console entry
- document the new viewer in the README

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68529912333083318850056e55b3ef6e