### PR TITLE
Add SDF template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For complete details, please refer to the included `industrial_deployment_guide.
 - Step-by-step instructions for running the full system: [docs/full_system_run_guide.md](docs/full_system_run_guide.md)
 - Guide for integrating new robots: [docs/robot_integration_guide.md](docs/robot_integration_guide.md)
 - Guide for running the test suite: [docs/testing_guide.md](docs/testing_guide.md)
+- Example SDF-based configuration: `src/simulation_core/config/sdf_example.yaml`
 
 ## Commercial Applications
 

--- a/src/simulation_core/config/sdf_example.yaml
+++ b/src/simulation_core/config/sdf_example.yaml
@@ -1,0 +1,8 @@
+description: Example configuration using an SDF model
+environment:
+  type: demo_world
+  size: [5.0, 5.0, 3.0]
+robots:
+  - id: template_sdf_robot
+    type: template
+    model_file: ../../templates/robot_description/template_robot.sdf

--- a/templates/robot_description/template_robot.sdf
+++ b/templates/robot_description/template_robot.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  Minimal SDF robot description template.
+  Replace 'template_robot' with your robot's name and add link/joint
+  definitions where indicated.
+-->
+<sdf version="1.6">
+  <model name="template_robot">
+    <!-- Insert link elements here -->
+    <!--
+    <link name="base_link">
+      <!-- Define base link geometry -->
+    </link>
+    -->
+
+    <!-- Insert joint elements here -->
+    <!--
+    <joint name="joint1" type="revolute">
+      <parent>base_link</parent>
+      <child>link1</child>
+    </joint>
+    -->
+  </model>
+</sdf>


### PR DESCRIPTION
## Summary
- add SDF robot description template
- create example config referencing the SDF
- document the example in the README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a1944c408331a465491a9851a788