### PR TITLE
Add API documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ checkpoints/
 
 # Temporary data generated at runtime
 *.npy
+docs/api/build/
 *.npz
 *.tmp
 *.log

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ For complete details, please refer to the included `industrial_deployment_guide.
 - Step-by-step instructions for running the full system: [docs/full_system_run_guide.md](docs/full_system_run_guide.md)
 - Guide for integrating new robots: [docs/robot_integration_guide.md](docs/robot_integration_guide.md)
 - Guide for running the test suite: [docs/testing_guide.md](docs/testing_guide.md)
+- API documentation can be generated using Sphinx:
+  ```bash
+  cd docs/api
+  make html
+  ```
 - Example SDF-based configuration: `src/simulation_core/config/sdf_example.yaml`
 
 ## Commercial Applications

--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -1,0 +1,27 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+SRCDIR        = ../../src
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile apidocs
+
+apidocs:
+	$(SPHINXBUILD) -m sphinx.ext.apidoc -o $(SOURCEDIR) $(SRCDIR)
+
+html: apidocs
+	@$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O)
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api/make.bat
+++ b/docs/api/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/api/source/conf.py
+++ b/docs/api/source/conf.py
@@ -1,0 +1,41 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Industrial Robotics'
+copyright = '2025, Industrial Robotics Team'
+author = 'Industrial Robotics Team'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..', 'src')))
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -1,0 +1,8 @@
+Industrial Robotics API Documentation
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/tests/test_fmm_core_nodes.py
+++ b/tests/test_fmm_core_nodes.py
@@ -371,7 +371,7 @@ def test_pick_and_place_node_parameters(monkeypatch):
     sys.modules.pop('fmm_core.fmm_core.pick_and_place_node', None)
     from fmm_core.fmm_core import pick_and_place_node as ppn
 
-    node = ppn.PickAndPlaceNode()
+    ppn.PickAndPlaceNode()
 
     mg = sys.modules['moveit_commander'].MoveGroupCommander.last_instance
     assert mg.planning_time == 5.0


### PR DESCRIPTION
## Summary
- initialize Sphinx project under `docs/api`
- configure autodoc and Napoleon extensions
- add Makefile target to build docs
- document the build process in README

## Testing
- `flake8 src tests`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6852acfc6fb08331ae33a32bfd23cd5a