### PR TITLE
Add profiling tools

### DIFF
--- a/docs/performance_guide.md
+++ b/docs/performance_guide.md
@@ -1,0 +1,39 @@
+# Performance Profiling Guide
+
+This guide explains how to measure execution time for the simulation loop and perception nodes using the utilities in `tools/profiling`.
+
+## 1. Install Optional Dependencies
+
+The examples use Python's built-in `cProfile` module. For more detailed reports you can install `pyinstrument`:
+
+```bash
+pip install pyinstrument
+```
+
+## 2. Profile the Simulation Loop
+
+Run the helper script to execute a dummy simulation loop under the profiler:
+
+```bash
+python tools/profiling/profile_simulation.py --steps 5000
+```
+
+The results are written to `simulation_profile.prof`. Open the file with the `pstats` module or a viewer such as `snakeviz`.
+
+To use `pyinstrument` instead:
+
+```bash
+python tools/profiling/profile_simulation.py --profiler pyinstrument
+```
+
+## 3. Profile a Perception Pipeline
+
+The perception example processes synthetic images:
+
+```bash
+python tools/profiling/profile_perception.py --images 200
+```
+
+Specify `--profiler pyinstrument` to use `pyinstrument` if installed. Results are saved to `perception_profile.prof`.
+
+Both scripts are minimal templates. Replace the dummy functions with calls into your actual simulation or perception nodes to analyse their performance.

--- a/tools/profiling/profile_perception.py
+++ b/tools/profiling/profile_perception.py
@@ -1,0 +1,38 @@
+"""Example script to profile a dummy perception pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import cv2
+import numpy as np
+
+from profiling_utils import run_with_cprofile, run_with_pyinstrument
+
+
+def perception_pipeline(images: int) -> None:
+    """Run a simple image processing loop."""
+    for _ in range(images):
+        img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        _ = cv2.Canny(gray, 100, 200)
+        time.sleep(0.001)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile the perception pipeline")
+    parser.add_argument("--images", type=int, default=100, help="Number of images to process")
+    parser.add_argument("--profiler", choices=["cprofile", "pyinstrument"], default="cprofile")
+    parser.add_argument("--output", default="perception_profile.prof", help="Output file")
+    args = parser.parse_args()
+
+    if args.profiler == "pyinstrument":
+        run_with_pyinstrument(perception_pipeline, args.images, output=args.output)
+    else:
+        run_with_cprofile(perception_pipeline, args.images, output=args.output)
+    print(f"Profiling complete. Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling/profile_simulation.py
+++ b/tools/profiling/profile_simulation.py
@@ -1,0 +1,35 @@
+"""Example script to profile a simple simulation loop."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from profiling_utils import run_with_cprofile, run_with_pyinstrument
+
+
+def simulation_loop(steps: int) -> None:
+    """Dummy simulation loop used for profiling."""
+    value = 0
+    for i in range(steps):
+        value += i * i
+        time.sleep(0.001)
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile the simulation loop")
+    parser.add_argument("--steps", type=int, default=1000, help="Number of loop iterations")
+    parser.add_argument("--profiler", choices=["cprofile", "pyinstrument"], default="cprofile")
+    parser.add_argument("--output", default="simulation_profile.prof", help="Output file")
+    args = parser.parse_args()
+
+    if args.profiler == "pyinstrument":
+        run_with_pyinstrument(simulation_loop, args.steps, output=args.output)
+    else:
+        run_with_cprofile(simulation_loop, args.steps, output=args.output)
+    print(f"Profiling complete. Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling/profiling_utils.py
+++ b/tools/profiling/profiling_utils.py
@@ -1,0 +1,38 @@
+"""Utilities for running performance profilers."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+import cProfile
+import pstats
+
+
+try:
+    from pyinstrument import Profiler
+except Exception:  # pyinstrument is optional
+    Profiler = None  # type: ignore
+
+
+__all__ = ["run_with_cprofile", "run_with_pyinstrument"]
+
+
+def run_with_cprofile(func: Callable[..., Any], *args: Any, output: str = "profile.prof", **kwargs: Any) -> None:
+    """Run ``func`` with ``cProfile`` and write stats to ``output``."""
+    profiler = cProfile.Profile()
+    profiler.enable()
+    func(*args, **kwargs)
+    profiler.disable()
+    stats = pstats.Stats(profiler)
+    stats.dump_stats(output)
+
+
+def run_with_pyinstrument(func: Callable[..., Any], *args: Any, output: str = "profile.txt", **kwargs: Any) -> None:
+    """Run ``func`` with ``pyinstrument`` if available."""
+    if Profiler is None:
+        raise RuntimeError("pyinstrument is not installed")
+    profiler = Profiler()
+    profiler.start()
+    func(*args, **kwargs)
+    profiler.stop()
+    with open(output, "w", encoding="utf-8") as f:
+        f.write(profiler.output_text(unicode=True, color=False))


### PR DESCRIPTION
## Summary
- add profiling utilities using cProfile or pyinstrument
- show example scripts for profiling loops and perception pipelines
- document how to use the profilers

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6852b354479883318d53224aa41a0e94