### PR TITLE
Add perception plugin registry

### DIFF
--- a/docs/robot_integration_guide.md
+++ b/docs/robot_integration_guide.md
@@ -80,3 +80,24 @@ setup(
 
 The `controller_type` parameter of `RobotControlNode` selects which controller
 plugin to load at runtime.
+
+## Registering Perception Node Plugins
+
+Perception nodes can also be added via entry points. Define the
+`simulation_core.perception_nodes` group in your package and provide a mapping
+from a short name to the node class:
+
+```python
+setup(
+    ...,
+    entry_points={
+        'simulation_core.perception_nodes': [
+            'my_segmenter = my_pkg.segmentation:SegmentationNode',
+            'my_pose = my_pkg.pose:PoseEstimationNode',
+        ],
+    },
+)
+```
+
+Use the plugin name when launching your perception pipeline to select the
+desired implementation.

--- a/src/advanced_perception/setup.py
+++ b/src/advanced_perception/setup.py
@@ -32,5 +32,9 @@ setup(
             'segmentation_node = advanced_perception.segmentation_node:main',
             'pose_estimation_node = advanced_perception.pose_estimation_node:main',
         ],
+        'simulation_core.perception_nodes': [
+            'segmentation = advanced_perception.segmentation_node:SegmentationNode',
+            'pose_estimation = advanced_perception.pose_estimation_node:PoseEstimationNode',
+        ],
     },
 )

--- a/src/simulation_core/simulation_core/registry.py
+++ b/src/simulation_core/simulation_core/registry.py
@@ -1,10 +1,11 @@
-"""Discovery registry for robot and controller plugins."""
+"""Discovery registry for robot, controller and perception plugins."""
 
 from importlib import metadata
 from typing import Any, Dict, Type
 
 _robot_classes: Dict[str, Type[Any]] = {}
 _controller_classes: Dict[str, Type[Any]] = {}
+_perception_classes: Dict[str, Type[Any]] = {}
 _discovered = False
 
 
@@ -26,6 +27,12 @@ def _discover_entrypoints() -> None:
         except Exception:
             continue
         _controller_classes.setdefault(ep.name, cls)
+    for ep in eps.select(group="simulation_core.perception_nodes"):
+        try:
+            cls = ep.load()
+        except Exception:
+            continue
+        _perception_classes.setdefault(ep.name, cls)
     _discovered = True
 
 
@@ -41,6 +48,12 @@ def get_controller(name: str):
     return _controller_classes.get(name)
 
 
+def get_perception_node(name: str):
+    """Return registered perception node class by name or None."""
+    _discover_entrypoints()
+    return _perception_classes.get(name)
+
+
 def register_robot(name: str, cls: Type[Any]) -> None:
     """Manually register a robot class."""
     _robot_classes[name] = cls
@@ -51,8 +64,20 @@ def register_controller(name: str, cls: Type[Any]) -> None:
     _controller_classes[name] = cls
 
 
+def register_perception_node(name: str, cls: Type[Any]) -> None:
+    """Manually register a perception node class."""
+    _perception_classes[name] = cls
+
+
 class BasicController:
     """Default no-op controller used when none is specified."""
 
 
 register_controller("basic", BasicController)
+
+
+class BasicPerceptionNode:
+    """Fallback perception node doing nothing."""
+
+
+register_perception_node("basic", BasicPerceptionNode)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,8 +18,12 @@ def test_entrypoint_discovery(monkeypatch):
     class MyController:
         pass
 
+    class MyPerception:
+        pass
+
     plugin_mod.MyRobot = MyRobot
     plugin_mod.MyController = MyController
+    plugin_mod.MyPerception = MyPerception
     sys.modules['plugin_mod'] = plugin_mod
 
     ep_robot = md.EntryPoint(
@@ -28,15 +32,20 @@ def test_entrypoint_discovery(monkeypatch):
     ep_controller = md.EntryPoint(
         name='my_controller', value='plugin_mod:MyController', group='simulation_core.controllers'
     )
-    eps = md.EntryPoints([ep_robot, ep_controller])
+    ep_perception = md.EntryPoint(
+        name='my_perception', value='plugin_mod:MyPerception', group='simulation_core.perception_nodes'
+    )
+    eps = md.EntryPoints([ep_robot, ep_controller, ep_perception])
     monkeypatch.setattr(md, 'entry_points', lambda: eps)
 
     registry._robot_classes.clear()
     registry._controller_classes.clear()
+    registry._perception_classes.clear()
     registry._discovered = False
 
     assert registry.get_robot('my_robot') is MyRobot
     assert registry.get_controller('my_controller') is MyController
+    assert registry.get_perception_node('my_perception') is MyPerception
 
     registry.register_controller('basic', registry.BasicController)
     sys.modules.pop('plugin_mod')


### PR DESCRIPTION
## Summary
- extend registry with perception node lookup
- register segmentation and pose estimation nodes as plugins
- document perception plugin registration
- validate registry loads perception plugins

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: test_pick_and_place_node_parameters)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc00df9083319a2265ff4a8f0652