### PR TITLE
Update CI type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt || pip install $(grep -v '^rclpy' requirements.txt
-          pip install flake8 pytest
-          pip install mypy
+          pip install -r requirements.txt || pip install $(grep -v '^rclpy' requirements.txt)
+          pip install flake8 mypy pytest
       - name: Lint
         run: flake8 src tests
       - name: Type check
-        run: mypy --config-file mypy.ini src/simulation_core/simulation_core/environment_configurator_node.py src/web_interface_backend/web_interface_backend/web_interface_node.py
+        run: mypy --config-file mypy.ini src
       - name: Test
         run: pytest --cov=src --cov-report=xml -q

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,5 @@
 python_version = 3.12
 ignore_missing_imports = True
 files = src
+exclude = .*setup.py|.*/launch/.*\.py
+disable_error_code = import-not-found,import-untyped

--- a/src/simulation_tools/simulation_tools/object_3d_viewer_node.py
+++ b/src/simulation_tools/simulation_tools/object_3d_viewer_node.py
@@ -27,7 +27,7 @@ class Object3DViewerNode(Node):
             10,
         )
 
-        self.objects = []
+        self.objects: list[tuple[float, float, float]] = []
         self.lock = threading.Lock()
 
         plt.ion()


### PR DESCRIPTION
## Summary
- run mypy on entire `src` directory
- simplify CI steps
- annotate `objects` member in viewer node
- silence missing-type errors in mypy config

## Testing
- `flake8 src tests`
- `mypy --config-file mypy.ini src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_socketio')*

------
https://chatgpt.com/codex/tasks/task_e_6852e0641fcc8331b5f86adcf912e96a