### PR TITLE
Add pymodbus dependency

### DIFF
--- a/src/industrial_protocols/package.xml
+++ b/src/industrial_protocols/package.xml
@@ -11,6 +11,7 @@
   <depend>python3-yaml</depend>
   <depend>asyncua</depend>
   <depend>paho-mqtt</depend>
+  <depend>pymodbus</depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
## Summary
- include pymodbus in package.xml for industrial_protocols

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: AttributeError in test_pick_and_place_node_parameters)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0af67b88331a601f7844111c28c