### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/src/apm_core/package.xml
+++ b/src/apm_core/package.xml
@@ -14,6 +14,8 @@
   <depend>cv_bridge</depend>
   <depend>python3-opencv</depend>
   <depend>numpy</depend>
+  <depend>onnxruntime</depend>
+  <depend>python3-yaml</depend>
   <depend>launch</depend>
   <depend>launch_ros</depend>
 


### PR DESCRIPTION
## Summary
- update `apm_core` ROS package manifest to include required runtime deps

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852e0b027d483318a8d9786460a2736