### PR TITLE
Update setup to install subpackages

### DIFF
--- a/src/robot_interfaces/setup.py
+++ b/src/robot_interfaces/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 package_name = 'robot_interfaces'
 
 setup(
     name=package_name,
     version='0.2.0',
-    packages=[package_name],
+    packages=find_packages(include=[package_name, f"{package_name}.*"]),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),


### PR DESCRIPTION
## Summary
- use `find_packages()` in `robot_interfaces` setup so subpackages are included

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_socketio')*

------
https://chatgpt.com/codex/tasks/task_e_6852e0b306ac833194b4d6dc4150cfa7