### PR TITLE
Add experiment runner guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For complete details, please refer to the included `industrial_deployment_guide.
   make html
   ```
 - Example SDF-based configuration: `src/simulation_core/config/sdf_example.yaml`
+- Guide for running scripted experiments: [docs/experiment_runner.md](docs/experiment_runner.md)
 
 ## Commercial Applications
 

--- a/docs/experiment_runner.md
+++ b/docs/experiment_runner.md
@@ -1,0 +1,47 @@
+# Experiment Runner Guide
+
+This document explains how to use the `run_experiment.py` script to launch reproducible simulation experiments.
+
+## Usage
+
+Run the script from the repository root and pass a YAML or JSON configuration file:
+
+```bash
+python scripts/run_experiment.py --config my_experiment.yaml
+```
+
+The script parses the file and constructs a `ros2 launch` command for `simulation_tools/integrated_system_launch.py`.
+All recognized keys map directly to the launch arguments used by `integrated_system_launch.py`.
+
+## Sample Configuration
+
+```yaml
+use_realsense: false
+use_advanced_perception: true
+scenario: pick_and_place
+config_dir: configs/demo
+data_dir: /tmp/sim_data
+save_images: true
+allow_unsafe_werkzeug: true
+opcua_port: 4840
+```
+
+An equivalent JSON file may be used with the same keys.
+
+## Script Behaviour
+
+`run_experiment.py` reads the configuration, converts boolean values to the strings expected by ROS 2 launch and invokes:
+
+```bash
+ros2 launch simulation_tools integrated_system_launch.py \
+  use_realsense:=<true|false> \
+  use_advanced_perception:=<true|false> \
+  scenario:=<scenario> \
+  config_dir:=<config_dir> \
+  data_dir:=<data_dir> \
+  save_images:=<true|false> \
+  allow_unsafe_werkzeug:=<true|false> \
+  opcua_port:=<port>
+```
+
+Any unknown keys in the configuration file are ignored.


### PR DESCRIPTION
## Summary
- document how to use `run_experiment.py`
- link the new guide from README

## Testing
- `flake8 src tests`
- `pytest -k 'not pick_and_place_node_parameters'`

------
https://chatgpt.com/codex/tasks/task_e_6852e0fe92908331a2e6646820129212