### PR TITLE
Update ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 build/
 install/
 log/
+logs/
+run_logs/
+runtime_logs/
 *.pyc
 __pycache__/
 # Large binary formats
@@ -15,6 +18,14 @@ __pycache__/
 # Model checkpoint directories
 checkpoint/
 checkpoints/
+
+# Runtime data directory
+data/**
+!data/README.md
+
+# Generated configuration directories
+configs/
+generated_configs/
 
 # Temporary data generated at runtime
 *.npy

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ git lfs checkout path/to/file
 
 You can also discard local modifications with `git restore path/to/file`.
 
+## Ignored Paths
+
+Temporary data and logs are not stored in version control. The `data/` folder is
+used for runtime outputs, while scripts may create configuration files under
+`configs/`. These locations are listed in `.gitignore` so your local runs don't
+pollute commits.
+
 ## Docker Usage
 
 Build the image from the repository root:

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,2 @@
+This directory stores simulation outputs, logs, and other runtime data.
+Files here are ignored by Git except for this README.


### PR DESCRIPTION
## Summary
- ignore runtime data and log folders
- add ignore entries for generated configs
- keep data/ with a README sample
- document ignored paths in README

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: 'NoneType' has no attribute 'planning_time')*

------
https://chatgpt.com/codex/tasks/task_e_68531381d6e0833198d80e5d68c7676a