### PR TITLE
Add planning benchmark script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1] - 2025-06-19
+### Added
+- MoveIt planning benchmark script and documentation.
+
 All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - 2025-06-18

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For complete details, please refer to the included `industrial_deployment_guide.
 - Guide for integrating new robots: [docs/robot_integration_guide.md](docs/robot_integration_guide.md)
 - Guide for running the test suite: [docs/testing_guide.md](docs/testing_guide.md)
 - See [CHANGELOG.md](CHANGELOG.md) for release history
+- Benchmark planning and perception: [docs/benchmarking_guide.md](docs/benchmarking_guide.md)
 - API documentation can be generated using Sphinx:
   ```bash
   cd docs/api

--- a/docs/benchmarking_guide.md
+++ b/docs/benchmarking_guide.md
@@ -49,3 +49,32 @@ python scripts/benchmark_perception.py \
   --annotations /data/annotations.json \
   --model path/to/model.onnx
 ```
+
+## Planning Benchmark
+
+The `benchmark_planning.py` script measures MoveIt planning performance.
+It executes a series of named poses and records planning time, success
+rate and average trajectory duration.
+
+Run the planner benchmark with:
+
+```bash
+python scripts/benchmark_planning.py \
+  --group manipulator \
+  --poses home ready pick \
+  --trials 5 \
+  --output planning_results.json
+```
+
+The output JSON contains metrics for each pose:
+
+```json
+[
+  {
+    "pose": "home",
+    "avg_planning_time": 1.2,
+    "success_rate": 0.8,
+    "avg_trajectory_duration": 3.4
+  }
+]
+```

--- a/scripts/benchmark_planning.py
+++ b/scripts/benchmark_planning.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Benchmark MoveIt planning for predefined poses."""
+
+import argparse
+import json
+from time import perf_counter
+from typing import List
+
+import moveit_commander
+import rclpy
+
+
+def run_benchmark(group_name: str, poses: List[str], trials: int) -> List[dict]:
+    """Execute planning for each pose and collect metrics."""
+    moveit_commander.roscpp_initialize([])
+    rclpy.init()
+
+    group = moveit_commander.MoveGroupCommander(group_name)
+    results = []
+
+    for pose in poses:
+        successes = 0
+        planning_times = []
+        traj_durations = []
+        for _ in range(trials):
+            group.set_named_target(pose)
+            start = perf_counter()
+            success, plan, _, _ = group.plan()
+            planning_times.append(perf_counter() - start)
+            if success:
+                duration = 0.0
+                try:
+                    duration = (
+                        plan.joint_trajectory.points[-1].time_from_start.to_sec()
+                    )
+                except Exception:
+                    pass
+                traj_durations.append(duration)
+                group.execute(plan, wait=True)
+                successes += 1
+            group.clear_pose_targets()
+        count = len(planning_times)
+        results.append(
+            {
+                "pose": pose,
+                "avg_planning_time": sum(planning_times) / count if count else 0.0,
+                "success_rate": successes / count if count else 0.0,
+                "avg_trajectory_duration": (
+                    sum(traj_durations) / len(traj_durations)
+                    if traj_durations
+                    else 0.0
+                ),
+            }
+        )
+
+    rclpy.shutdown()
+    moveit_commander.roscpp_shutdown()
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark MoveIt planning for predefined poses"
+    )
+    parser.add_argument(
+        "--group",
+        default="manipulator",
+        help="MoveIt planning group name",
+    )
+    parser.add_argument(
+        "--poses",
+        nargs="+",
+        default=["home"],
+        help="Named target poses to execute",
+    )
+    parser.add_argument(
+        "--trials", type=int, default=5, help="Number of planning attempts"
+    )
+    parser.add_argument(
+        "--output", default="planning_benchmark.json", help="Results file"
+    )
+    args = parser.parse_args()
+
+    metrics = run_benchmark(args.group, args.poses, args.trials)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `benchmark_planning.py` for measuring MoveIt planning performance
- document planning benchmarking usage
- reference benchmarking guide in README
- note new tool in CHANGELOG

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: AttributeError in `test_pick_and_place_node_parameters`)*

------
https://chatgpt.com/codex/tasks/task_e_6853138995c48331a315507e94be03a4