### PR TITLE
Add perception benchmarking notebook

### DIFF
--- a/docs/benchmarking_guide.md
+++ b/docs/benchmarking_guide.md
@@ -49,3 +49,16 @@ python scripts/benchmark_perception.py \
   --annotations /data/annotations.json \
   --model path/to/model.onnx
 ```
+
+## Notebook Usage
+
+An interactive notebook is provided in `notebooks/benchmark_perception_demo.ipynb`.
+Launch it from the repository root:
+
+```bash
+jupyter notebook notebooks/benchmark_perception_demo.ipynb
+```
+
+Edit the paths in the first code cell to point to your dataset. Running the
+cells executes the benchmark and displays a bar chart of per-class AP values with
+the overall mAP in the title.

--- a/notebooks/benchmark_perception_demo.ipynb
+++ b/notebooks/benchmark_perception_demo.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmark Perception Demo\n",
+    "This notebook shows how to execute `benchmark_perception.py` from Python and visualize the mAP results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess, json, matplotlib.pyplot as plt\n",
+    "\n",
+    "images_dir = '/path/to/images'  # Update with your dataset\n",
+    "annotations = '/path/to/annotations.json'\n",
+    "output_file = 'results.json'\n",
+    "\n",
+    "subprocess.run([\n",
+    "    'python', '../scripts/benchmark_perception.py',\n",
+    "    '--images', images_dir,\n",
+    "    '--annotations', annotations,\n",
+    "    '--output', output_file\n",
+    "], check=True)\n",
+    "\n",
+    "with open(output_file) as f:\n",
+    "    results = json.load(f)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ap = results['AP_per_class']\n",
+    "plt.figure(figsize=(8,4))\n",
+    "plt.bar(ap.keys(), ap.values())\n",
+    "plt.ylabel('Average Precision')\n",
+    "plt.title(f"mAP: {results['mAP']:.2f}")\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/advanced_perception/advanced_perception/segmentation_node.py
+++ b/src/advanced_perception/advanced_perception/segmentation_node.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 import cv2
 import numpy as np
 import rclpy
+import yaml  # type: ignore
 from cv_bridge import CvBridge
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node

--- a/tests/test_fmm_core_nodes.py
+++ b/tests/test_fmm_core_nodes.py
@@ -368,7 +368,6 @@ def test_pick_and_place_node_locations(monkeypatch):
 
 
 @pytest.mark.xfail(reason="MoveGroupCommander stub not retained between tests")
-
 def test_pick_and_place_node_parameters(monkeypatch):
     overrides = {
         'max_velocity_scaling_factor': 0.8,


### PR DESCRIPTION
## Summary
- add Jupyter notebook demonstrating how to invoke benchmark_perception
- document notebook usage in benchmarking guide
- import yaml in segmentation node
- fix flake8 warning in fmm core tests

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853138a2f3c83318c138abae30de08a