### PR TITLE
Use ROS package paths for perception models

### DIFF
--- a/scripts/benchmark_perception.py
+++ b/scripts/benchmark_perception.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 from pathlib import Path
+from ament_index_python.packages import get_package_share_directory
 
 import cv2
 import numpy as np
@@ -151,9 +152,14 @@ def main():
                         help="Path to image directory")
     parser.add_argument("--annotations", required=True,
                         help="Path to COCO annotations JSON")
-    parser.add_argument("--model",
-                        default="src/apm_core/models/ssd_mobilenet_v2.onnx",
-                        help="Path to ONNX detection model")
+    default_model = Path(
+        get_package_share_directory("apm_core")
+    ) / "models" / "ssd_mobilenet_v2.onnx"
+    parser.add_argument(
+        "--model",
+        default=str(default_model),
+        help="Path to ONNX detection model",
+    )
     parser.add_argument("--output", default="benchmark_results.json",
                         help="File to write metrics")
     args = parser.parse_args()

--- a/src/apm_core/config/default_object_detection_config.yaml
+++ b/src/apm_core/config/default_object_detection_config.yaml
@@ -2,14 +2,14 @@
 
 object_detection:
   model:
-    path: "/home/ubuntu/ros2_apm_fmm_ws/install/apm_core/share/apm_core/models/ssd_mobilenet_v2.onnx"
+    path: "$(find apm_core)/models/ssd_mobilenet_v2.onnx"
     input_name: "input_tensor"
     output_names: ["detection_boxes", "detection_scores", "detection_classes"]
     input_size: [320, 320]
     confidence_threshold: 0.5
     
   classes:
-    path: "/home/ubuntu/ros2_apm_fmm_ws/install/apm_core/share/apm_core/config/coco_classes.txt"
+    path: "$(find apm_core)/config/coco_classes.txt"
     
   processing:
     enable_gpu: false


### PR DESCRIPTION
## Summary
- use `$(find apm_core)` paths in the default object detection config
- resolve the model path in `benchmark_perception.py` using `get_package_share_directory`

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855d26f754883318a734b2e9b3aa869