### PR TITLE
Update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.3.0
+numpy==2.2.6
 opencv-python==4.11.0.86
 flask==3.1.1
 flask-socketio==5.5.1


### PR DESCRIPTION
## Summary
- use numpy 2.2.6 instead of 2.3.0

## Testing
- `pip install -r requirements.txt`
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856e341141c83318ae07deddef43386