### PR TITLE
Add dev tools to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ functionality, place the corresponding test cases in this directory.
 ### Code Style
 
 `flake8` checks are provided to help maintain consistent code formatting.
-Install the tool and run it against the source tree before submitting changes:
+Install all development dependencies and run the style checker before submitting changes:
 
 ```bash
-pip install flake8
+pip install -r requirements.txt
 flake8 src tests
 ```
 

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -4,11 +4,10 @@ This guide explains how to run the automated tests and style checks for the Indu
 
 ## 1. Install Dependencies
 
-Install the Python packages listed in `requirements.txt` along with the development tools:
+Install the Python packages and development tools listed in `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt
-pip install flake8 pytest pytest-cov
 ```
 
 The tests use stub modules so ROS&nbsp;2 is not required. Ensure all dependencies are available in your environment before running the suite.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ paho-mqtt==2.1.0
 onnxruntime==1.22.0
 pytest-cov==6.2.1
 flask-login==0.6.3
+flake8
+mypy
+pytest


### PR DESCRIPTION
## Summary
- include flake8, mypy, and pytest in requirements.txt
- update docs to install all development requirements

## Testing
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856e3412dbc8331935067015345bc06