### PR TITLE
Fix rosdep build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ WORKDIR /opt/industrial_ws
 COPY . /opt/industrial_ws
 
 # Install system dependencies and Python requirements
+RUN python3 -m pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 RUN apt-get update && \
     rosdep update && \
     rosdep install --from-paths src -y --ignore-src \
         --rosdistro humble \
-        --skip-keys "ament_python flask-socketio pymodbus pyyaml moveit_commander onnxruntime" && \
-    pip install --no-cache-dir -r requirements.txt && \
+        --skip-keys "ament_python flask-socketio pymodbus pyyaml moveit_commander onnxruntime flask paho-mqtt numpy" && \
     . /opt/ros/humble/setup.sh && \
     colcon build
 


### PR DESCRIPTION
## Summary
- install pip requirements before rosdep
- skip flask, paho-mqtt and numpy in rosdep install

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6857e5e5e3948331950cd25aab3cfd2f