### PR TITLE
Add web secret key parameter

### DIFF
--- a/docs/experiment_runner.md
+++ b/docs/experiment_runner.md
@@ -23,6 +23,7 @@ config_dir: configs/demo
 data_dir: /tmp/sim_data
 save_images: true
 allow_unsafe_werkzeug: true
+secret_key: mysecret
 opcua_port: 4840
 ```
 
@@ -41,7 +42,11 @@ ros2 launch simulation_tools integrated_system_launch.py \
   data_dir:=<data_dir> \
   save_images:=<true|false> \
   allow_unsafe_werkzeug:=<true|false> \
+  secret_key:=<key> \
   opcua_port:=<port>
 ```
+
+The secret key may also be provided via the `WEB_INTERFACE_SECRET`
+environment variable.
 
 Any unknown keys in the configuration file are ignored.

--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -59,6 +59,7 @@ class WebInterfaceNode(Node):
         super().__init__('web_interface_node')
         
         # Declare parameters using a single dictionary
+        secret_env = os.environ.get('WEB_INTERFACE_SECRET', 'secret')
         param_defaults = {
             'port': 8080,
             'host': '0.0.0.0',
@@ -71,6 +72,7 @@ class WebInterfaceNode(Node):
             'detected_objects_topic': '/apm/detection/objects',
             'joint_states_topic': '/joint_states',
             'auto_open_browser': False,
+            'secret_key': secret_env,
         }
         self.declare_parameters('', [(k, v) for k, v in param_defaults.items()])
         
@@ -86,6 +88,7 @@ class WebInterfaceNode(Node):
         self.detected_objects_topic = self.get_parameter('detected_objects_topic').value
         self.joint_states_topic = self.get_parameter('joint_states_topic').value
         self.auto_open_browser = self.get_parameter('auto_open_browser').value
+        self.secret_key = self.get_parameter('secret_key').value
 
         if not self.log_db_path:
             if self.data_dir:
@@ -176,7 +179,7 @@ class WebInterfaceNode(Node):
         self.app = Flask(__name__,
                          template_folder=template_folder_path,
                          static_folder=static_folder_path)
-        self.app.secret_key = 'secret'
+        self.app.secret_key = self.secret_key
 
         self.login_manager = LoginManager()
         self.login_manager.login_view = 'login'

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -200,7 +200,7 @@ def test_error_sim_rate_bounds(tmp_path):
     assert dummy.error_simulation_rate == 0.0
 
 
-def test_web_interface_logger_initialization_order(tmp_path):
+def test_web_interface_logger_initialization_order(tmp_path, monkeypatch):
     """Ensure data directory exists before ActionLogger is created."""
     import types
     import importlib
@@ -232,6 +232,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
                 'detected_objects_topic': '/apm/detection/objects',
                 'joint_states_topic': '/joint_states',
                 'auto_open_browser': False,
+                'secret_key': 'dummy_key',
             }
 
         def declare_parameters(self, ns, params):
@@ -269,6 +270,7 @@ def test_web_interface_logger_initialization_order(tmp_path):
         'numpy': types.ModuleType('numpy'),
         'yaml': types.ModuleType('yaml'),
     }
+    stub_modules['numpy'].typing = types.SimpleNamespace(NDArray=object)
 
     stub_modules['rclpy'].node = stub_modules['rclpy.node']
     stub_modules['rclpy.node'].Node = DummyNode
@@ -320,6 +322,8 @@ def test_web_interface_logger_initialization_order(tmp_path):
 
     for name, mod in stub_modules.items():
         sys.modules[name] = mod
+
+    monkeypatch.setenv("WEB_INTERFACE_SECRET", "dummy_key")
 
     win = importlib.import_module('web_interface_backend.web_interface_node')
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -69,6 +69,8 @@ def test_safety_monitor_node_defaults():
 
 
 def test_web_interface_node_defaults():
+    import os
+    os.environ["WEB_INTERFACE_SECRET"] = "dummy_key"
     from web_interface_backend.web_interface_node import WebInterfaceNode
     node = _init_node(WebInterfaceNode)
     assert node.get_parameter('allow_unsafe_werkzeug').value is True
@@ -79,6 +81,7 @@ def test_web_interface_node_defaults():
         node.get_parameter('detected_objects_topic').value
         == '/apm/detection/objects'
     )
+    assert node.get_parameter('secret_key').value == 'dummy_key'
 
 
 def test_visualization_server_node_defaults():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock
 def _setup_ros_stubs(monkeypatch):
     """Create minimal ROS stubs used across multiple tests."""
 
+    monkeypatch.setenv("WEB_INTERFACE_SECRET", "dummy_key")
+
     root = Path(__file__).resolve().parents[1]
 
     # rclpy and node stub


### PR DESCRIPTION
## Summary
- allow configuring Flask secret via `secret_key` parameter
- document `secret_key` option for experiment runner
- set dummy secret in tests

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f211b68083318ae8be67dd9bbab7