### PR TITLE
Clamp jpeg quality parameter

### DIFF
--- a/src/web_interface_backend/web_interface_backend/visualization_server_node.py
+++ b/src/web_interface_backend/web_interface_backend/visualization_server_node.py
@@ -37,6 +37,11 @@ class VisualizationServerNode(Node):
             )
             self.visualization_rate = 10.0
         self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
+        if not 0 <= self.jpeg_quality <= 100:
+            self.get_logger().warning(
+                f'Invalid jpeg_quality {self.jpeg_quality}, using 75 instead'
+            )
+            self.jpeg_quality = 75
         
         # Create data directory if it doesn't exist
         if self.data_dir and not os.path.exists(self.data_dir):

--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -83,6 +83,11 @@ class WebInterfaceNode(Node):
         self.allow_unsafe_werkzeug = self.get_parameter('allow_unsafe_werkzeug').value
         self.log_db_path = self.get_parameter('log_db_path').value
         self.jpeg_quality = int(self.get_parameter('jpeg_quality').value)
+        if not 0 <= self.jpeg_quality <= 100:
+            self.get_logger().warning(
+                f'Invalid jpeg_quality {self.jpeg_quality}, using 75 instead'
+            )
+            self.jpeg_quality = 75
         self.detected_objects_topic = self.get_parameter('detected_objects_topic').value
         self.joint_states_topic = self.get_parameter('joint_states_topic').value
         self.auto_open_browser = self.get_parameter('auto_open_browser').value


### PR DESCRIPTION
## Summary
- clamp `jpeg_quality` parameter between 0 and 100 for web interface
- apply same clamp in visualization server

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f21448d08331aab77aee2d1b2b47