### PR TITLE
Fix missing CMakeLists for meta package

### DIFF
--- a/industrial_robotics_simulation_platform_meta/CMakeLists.txt
+++ b/industrial_robotics_simulation_platform_meta/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.8)
+project(industrial_robotics_simulation_platform_meta)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()


### PR DESCRIPTION
## Summary
- add missing `CMakeLists.txt` for `industrial_robotics_simulation_platform_meta`

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858663e44bc833189c433990c3ba8bd