### PR TITLE
Add setup_and_test helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ Then execute:
 pytest
 ```
 
+You can also run the `setup_and_test.sh` helper script, which installs the
+dependencies and executes `flake8` followed by `pytest`:
+
+```bash
+scripts/setup_and_test.sh
+```
+
 ### Tests Directory
 
 All unit tests are located in the `tests/` folder. Each file targets a specific

--- a/scripts/setup_and_test.sh
+++ b/scripts/setup_and_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Install dependencies and run code style checks and tests.
+
+set -euo pipefail
+
+# Determine repository root directory
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+
+flake8 src tests
+pytest
+


### PR DESCRIPTION
## Summary
- add a helper script to set up dependencies and run tests
- reference the helper script in the README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abcf6194c8331982d703d0eaacef1