### PR TITLE
Add scenario template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For complete details, please refer to the included `industrial_deployment_guide.
   make html
   ```
 - Example SDF-based configuration: `src/simulation_core/config/sdf_example.yaml`
+- Scenario template snippets: [docs/scenario_templates.md](docs/scenario_templates.md)
 - Guide for running scripted experiments: [docs/experiment_runner.md](docs/experiment_runner.md)
 
 ## Commercial Applications

--- a/docs/scenario_templates.md
+++ b/docs/scenario_templates.md
@@ -1,0 +1,38 @@
+# Scenario Templates
+
+This document shows minimal examples of scenario configuration files. Both YAML and JSON formats are supported and share the same keys.
+
+## Example YAML
+
+```yaml
+# Based on src/simulation_core/config/sdf_example.yaml
+description: Example configuration using an SDF model
+environment:
+  type: demo_world
+  size: [5.0, 5.0, 3.0]
+robots:
+  - id: template_sdf_robot
+    type: template
+    model_file: ../../templates/robot_description/template_robot.sdf
+```
+
+## Equivalent JSON
+
+```json
+{
+  "description": "Example configuration using an SDF model",
+  "environment": {
+    "type": "demo_world",
+    "size": [5.0, 5.0, 3.0]
+  },
+  "robots": [
+    {
+      "id": "template_sdf_robot",
+      "type": "template",
+      "model_file": "../../templates/robot_description/template_robot.sdf"
+    }
+  ]
+}
+```
+
+Use these snippets as a starting point when defining your own scenarios. Additional sections such as conveyors, containers and sorting rules may be added as shown in other files under `src/simulation_core/config`.


### PR DESCRIPTION
## Summary
- add a new doc with YAML and JSON scenario templates
- link the new doc from the README

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685abcf7b6d08331b7678d72eb854296