### PR TITLE
Document error simulation rate

### DIFF
--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -87,3 +87,22 @@ ros2 run gazebo_ros spawn_entity.py \
 Navigate to [http://localhost:8080](http://localhost:8080) in your browser to control the simulation, add objects and monitor status.
 
 The full system is now running with Gazebo, RViz, object detection and the web dashboard.
+
+## 7. Adjust Error Simulation Rate
+
+The environment configurator node can randomly trigger errors during metrics
+updates. Control how often this happens using the `error_simulation_rate`
+parameter. A value of `0.0` disables error injection while `1.0` forces an error
+every cycle.
+
+Set the rate when launching the system:
+
+```bash
+ros2 launch simulation_core full_system.launch.py error_simulation_rate:=0.2
+```
+
+You can also change the value at runtime by publishing a configuration message:
+
+```bash
+ros2 topic pub /simulation/config std_msgs/msg/String '{"settings": {"simulation": {"error_simulation_rate": 0.5}}}'
+```

--- a/docs/performance_guide.md
+++ b/docs/performance_guide.md
@@ -56,3 +56,19 @@ python scripts/benchmark_planning.py \
 ```
 
 Results are written to `planning_profile.json` for further analysis alongside the simulation and perception profiles.
+
+## 5. Error Simulation Rate
+
+The simulation includes optional error injection controlled by the
+`error_simulation_rate` parameter. It defines the probability of triggering a
+random error whenever metrics are published. Acceptable values range from `0.0`
+(no errors) to `1.0` (an error every cycle).
+
+Set the parameter when launching the system:
+
+```bash
+ros2 launch simulation_core full_system.launch.py error_simulation_rate:=0.3
+```
+
+You can adjust the rate while the system is running using the same configuration
+topic described in the full system guide.


### PR DESCRIPTION
## Summary
- document error simulation rate settings in the full system guide
- mention the parameter in the performance guide

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac42d7e188331a02081c432581551