### PR TITLE
Improve export ID handling

### DIFF
--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -331,3 +331,25 @@ def test_save_scenario_endpoint(monkeypatch, tmp_path):
     data = json.loads(msg.data)
     assert data['update_scenario']['name'] == 'test'
     logger_mock.log.assert_called_with('save_scenario', {'id': 'test'})
+
+
+def test_download_export_invalid_id(monkeypatch, tmp_path):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    node.data_dir = str(tmp_path)
+
+    client = node.app.test_client()
+    _login(client)
+
+    res = client.get('/api/exports/..etc')
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- validate export ID format
- use a temporary directory for export archives
- test invalid export ID download fails

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac41e1a788331a3128399a9e0f015