### PR TITLE
Align mypy version with CI

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.12
+python_version = 3.10
 ignore_missing_imports = True
 files = src
 exclude = .*setup.py|.*/launch/.*\.py


### PR DESCRIPTION
## Summary
- set `python_version` to 3.10 in `mypy.ini`
- CI already uses Python 3.10 for type checking

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ac694bd4c83319864e24a9a56d9db