### PR TITLE
Remove unused imports

### DIFF
--- a/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
+++ b/src/fmm_core/fmm_core/fmm_moveit_interface_node.py
@@ -3,13 +3,11 @@
 
 import rclpy
 from rclpy.node import Node
-from moveit_msgs.msg import DisplayTrajectory, RobotTrajectory, MoveItErrorCodes
+from moveit_msgs.msg import DisplayTrajectory
 from moveit_msgs.srv import GetPositionIK, GetPositionFK
-from geometry_msgs.msg import Pose, PoseStamped, Point, Quaternion
-from sensor_msgs.msg import JointState
-from std_msgs.msg import Header, String
+from geometry_msgs.msg import Pose
+from std_msgs.msg import String
 from apm_msgs.msg import DetectedObject, DetectedObjectArray
-import numpy as np
 import tf2_ros
 from tf2_geometry_msgs import do_transform_pose
 from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup


### PR DESCRIPTION
## Summary
- clean up unused imports in `fmm_moveit_interface_node.py`

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685ac69728548331ba96d185658dbf8d