### PR TITLE
Add metrics update test for simulate_error

### DIFF
--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -350,3 +350,21 @@ def test_web_interface_logger_initialization_order(tmp_path, monkeypatch):
         pkg = sys.modules.get('web_interface_backend')
         if pkg and hasattr(pkg, 'web_interface_node'):
             delattr(pkg, 'web_interface_node')
+
+
+def test_simulate_error_updates_metrics(tmp_path):
+    dummy = make_dummy(tmp_path)
+    dummy.record_metrics = True
+    dummy.metrics = {
+        'cycle_time': 0.0,
+        'throughput': 0.0,
+        'accuracy': 100.0,
+        'errors': 0,
+        'objects_processed': 0,
+    }
+    dummy.running = True
+
+    ec.EnvironmentConfiguratorNode.simulate_error(dummy, 'gripper_failure')
+
+    assert dummy.metrics['errors'] == 1
+    assert dummy.metrics['accuracy'] == 95.0


### PR DESCRIPTION
## Summary
- add unit test for `simulate_error` metrics

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac6985e388331b3c10674f817cf31