### PR TITLE
Add Python version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The container will automatically launch the integrated system using
 ## Running Tests
 
 `pytest` is used for running the unit tests. After building the workspace,
-install any Python dependencies with:
+Python 3.10 is recommended when executing the test suite. Install any Python dependencies with:
 
 ```bash
 pip install -r requirements.txt

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -9,6 +9,7 @@ Install the Python packages and development tools listed in `requirements.txt`:
 ```bash
 pip install -r requirements.txt
 ```
+Python 3.10 is the recommended interpreter when running the test suite.
 
 The tests use stub modules so ROS&nbsp;2 is not required. Ensure all dependencies are available in your environment before running the suite.
 


### PR DESCRIPTION
## Summary
- mention Python 3.10 in README test instructions
- note recommended Python version in testing guide

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685ac69a35c4833189a56200976c776a