### PR TITLE
Add warning for unsupported robot commands

### DIFF
--- a/src/simulation_core/simulation_core/robot_control_node.py
+++ b/src/simulation_core/simulation_core/robot_control_node.py
@@ -60,6 +60,8 @@ class RobotControlNode(Node):
             out = String()
             out.data = 'execute'
             self.sequence_pub.publish(out)
+        else:
+            self.get_logger().warning(f'Unsupported command: {msg.data}')
 
 
 def main(args=None):

--- a/tests/test_robot_control_node.py
+++ b/tests/test_robot_control_node.py
@@ -59,3 +59,16 @@ def test_command_processing(monkeypatch):
     assert not node.jog_pub.publish.called
     assert not node.waypoint_pub.publish.called
     assert not node.sequence_pub.publish.called
+
+
+def test_unsupported_command_logs_warning(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    sys.modules.pop('simulation_core.robot_control_node', None)
+    sys.modules.pop('simulation_core', None)
+    from simulation_core import robot_control_node as rcn
+
+    node = rcn.RobotControlNode()
+
+    node.get_logger().warning.reset_mock()
+    node.command_callback(_msg('bad_cmd'))
+    node.get_logger().warning.assert_called_once_with('Unsupported command: bad_cmd')


### PR DESCRIPTION
## Summary
- log a warning when `robot_control_node` receives an unsupported command
- test that the warning is issued for bad commands

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac6af5b308331aac1919274c04fd8