### PR TITLE
Fix users.yaml loading

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -349,7 +349,7 @@ class WebInterfaceNode(Node):
             path = os.path.join(self.config_dir, 'users.yaml')
             if os.path.exists(path):
                 try:
-                    with open(path) as f:
+                    with open(path, 'r', encoding='utf-8') as f:
                         data = yaml.safe_load(f)
                     if isinstance(data, dict):
                         return {str(k): str(v) for k, v in data.items()}


### PR DESCRIPTION
## Summary
- open users.yaml with UTF-8 encoding in `WebInterfaceNode._load_users`

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac6b74bcc833189c2ca4d12e6d6e8