### PR TITLE
Add numpy skip check in tests

### DIFF
--- a/tests/test_pose_estimation_node_fallback.py
+++ b/tests/test_pose_estimation_node_fallback.py
@@ -1,8 +1,10 @@
 import sys
 import types
 from pathlib import Path
-import numpy as np
+import pytest
 from unittest.mock import MagicMock
+
+np = pytest.importorskip('numpy')
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / 'src' / 'advanced_perception'))

--- a/tests/test_pose_estimation_node_module.py
+++ b/tests/test_pose_estimation_node_module.py
@@ -2,9 +2,10 @@ import sys
 import types
 from pathlib import Path
 
-import numpy as np
-
+import pytest
 from test_utils import _setup_ros_stubs
+
+np = pytest.importorskip('numpy')
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / 'src' / 'advanced_perception'))

--- a/tests/test_segmentation_node_module.py
+++ b/tests/test_segmentation_node_module.py
@@ -3,9 +3,10 @@ import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import numpy as np
-
+import pytest
 from test_utils import _setup_ros_stubs
+
+np = pytest.importorskip('numpy')
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT / 'src' / 'advanced_perception'))


### PR DESCRIPTION
## Summary
- ensure pose and segmentation tests skip when numpy is missing

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_685ac6b93264833180792e80bb4eca3b