### PR TITLE
Fix test imports

### DIFF
--- a/tests/test_environment_configurator_shutdown.py
+++ b/tests/test_environment_configurator_shutdown.py
@@ -1,6 +1,11 @@
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 from test_utils import _setup_ros_stubs
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT / "src" / "simulation_core"))
 
 
 def test_shutdown_cancels_timers(monkeypatch):
@@ -15,6 +20,7 @@ def test_shutdown_cancels_timers(monkeypatch):
 
     sys.modules['rclpy.node'].Node.create_timer = create_timer
     sys.modules.pop('simulation_core.environment_configurator_node', None)
+    sys.modules.pop('simulation_core', None)
     from simulation_core import environment_configurator_node as ec
 
     monkeypatch.setattr(ec.EnvironmentConfiguratorNode, '_load_robot_models', lambda self: None)

--- a/tests/test_web_interface_runserver.py
+++ b/tests/test_web_interface_runserver.py
@@ -11,6 +11,12 @@ except ModuleNotFoundError:
 # reuse helper from API tests
 from test_utils import _setup_ros_stubs
 
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT / "src" / "web_interface_backend"))
+
 
 def test_run_server_fallback(monkeypatch):
     _setup_ros_stubs(monkeypatch)


### PR DESCRIPTION
## Summary
- fix path setup in environment configurator shutdown tests
- ensure web interface runserver test locates backend

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8331b0888331ab14717ac3de7e88