### PR TITLE
Handle invalid limit param

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -694,7 +694,12 @@ class WebInterfaceNode(Node):
         @self.app.route('/api/actions')
         @login_required
         def api_actions():
-            limit = int(request.args.get('limit', 100))
+            limit_str = request.args.get('limit', '100')
+            try:
+                limit = int(limit_str)
+            except ValueError:
+                return jsonify({'error': 'Invalid limit parameter'}), 400
+
             rows = []
             try:
                 rows = self.action_logger.get_recent_actions(limit)

--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -358,3 +358,24 @@ def test_download_export_invalid_id(monkeypatch, tmp_path):
 
     res = client.get('/api/exports/..etc')
     assert res.status_code == 400
+
+
+def test_actions_invalid_limit(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+    _login(client)
+
+    res = client.get('/api/actions?limit=bad')
+    assert res.status_code == 400
+


### PR DESCRIPTION
## Summary
- validate limit query parameter in API to avoid ValueError
- test invalid `limit` parameter handling

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8888f2b08331af2e90c13ac1345b