### PR TITLE
Fix doc config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Use `scripts/run_experiment.py` to launch the integrated system with
 parameters defined in a YAML or JSON configuration file:
 
 ```bash
-python scripts/run_experiment.py --config configs/my_experiment.yaml
+python scripts/run_experiment.py --config my_experiment.yaml
 ```
 
 The script reads options such as `scenario`, `use_realsense` and

--- a/docs/experiment_runner.md
+++ b/docs/experiment_runner.md
@@ -19,7 +19,7 @@ All recognized keys map directly to the launch arguments used by `integrated_sys
 use_realsense: false
 use_advanced_perception: true
 scenario: pick_and_place
-config_dir: configs/demo
+config_dir: src/simulation_core/config
 data_dir: /tmp/sim_data
 save_images: true
 allow_unsafe_werkzeug: true

--- a/docs/performance_guide.md
+++ b/docs/performance_guide.md
@@ -44,14 +44,14 @@ Use the `benchmark_planning.py` script to measure latency in the planning stack 
 
 ```bash
 python scripts/benchmark_planning.py \
-  --scenario configs/pick_and_place.yaml
+  --scenario src/simulation_core/config/pick_and_place.yaml
 ```
 
 Increase the number of iterations to stress test the planner and capture system-wide behaviour:
 
 ```bash
 python scripts/benchmark_planning.py \
-  --scenario configs/pick_and_place.yaml \
+  --scenario src/simulation_core/config/pick_and_place.yaml \
   --runs 50 --system-stats
 ```
 


### PR DESCRIPTION
## Summary
- update benchmarking scenario path in performance guide
- point experiment runner example to correct config directory
- remove leading `configs/` from experiment command in README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8d55daac833185b7ce357d30d859