### PR TITLE
Add run_sim launcher docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ The script reads options such as `scenario`, `use_realsense` and
 `use_advanced_perception` from the configuration file and forwards them
 to the underlying ROS launch command.
 
+## Simple Simulation Launch
+
+`scripts/run_sim.py` offers a lightweight wrapper around the default
+launch command. It starts the simulation with a few simple flags:
+
+```bash
+python scripts/run_sim.py --use-realsense
+```
+
 ## Handling Large Files
 
 Model weights and other large assets in the `models/` directory are stored using

--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -30,6 +30,9 @@ ros2 launch simulation_core full_system.launch.py \
     use_realsense:=false use_advanced_perception:=true
 ```
 
+A convenient wrapper for this command is available as
+[scripts/run_sim.py](../scripts/run_sim.py).
+
 If you prefer to start components separately for debugging, launch them
 individually:
 


### PR DESCRIPTION
## Summary
- document scripts/run_sim.py in README
- reference run_sim.py from the full system guide

## Testing
- `flake8 src tests`
- `pytest -q` *(fails: ModuleNotFoundError for flask_login and numpy.typing)*

------
https://chatgpt.com/codex/tasks/task_e_685e8d803cec8331800b6338a4899755