### PR TITLE
Implement near miss classification

### DIFF
--- a/src/simulation_core/simulation_core/collision_checker.py
+++ b/src/simulation_core/simulation_core/collision_checker.py
@@ -76,5 +76,11 @@ def detect_collisions(environment_config: Dict[str, Any] | List[_AABB], min_dist
             dz = max(a["min"][2] - b["max"][2], b["min"][2] - a["max"][2], 0.0)
             dist = (dx ** 2 + dy ** 2 + dz ** 2) ** 0.5
             if dist < min_distance:
-                violations.append({"type": "collision", "objects": [a["id"], b["id"]], "distance": dist})
+                violations.append(
+                    {
+                        "type": "near_miss",
+                        "objects": [a["id"], b["id"]],
+                        "distance": dist,
+                    }
+                )
     return violations

--- a/tests/test_collision_checker.py
+++ b/tests/test_collision_checker.py
@@ -28,4 +28,5 @@ def test_near_miss_detection(monkeypatch):
     assert detect_collisions(aabbs) == []
     near = detect_collisions(aabbs, min_distance=0.5)
     assert near
+    assert near[0]['type'] == 'near_miss'
     assert 'distance' in near[0]


### PR DESCRIPTION
## Summary
- report `near_miss` instead of `collision` when objects get closer than the minimum distance
- check for the new violation type in `test_near_miss_detection`

## Testing
- `python3 -m flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653a97e67883319f376c49a03dbe1f