### PR TITLE
Add setup.cfg to web interface backend

### DIFF
--- a/src/web_interface_backend/setup.cfg
+++ b/src/web_interface_backend/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/web_interface_backend
+[install]
+install_scripts=$base/lib/web_interface_backend


### PR DESCRIPTION
## Summary
- add `setup.cfg` for web_interface_backend so entrypoints install under `$base/lib/web_interface_backend`

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686943ec73b0833183da82d42c73081b