### PR TITLE
Add setup.cfg for industrial protocols

### DIFF
--- a/src/industrial_protocols/setup.cfg
+++ b/src/industrial_protocols/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/industrial_protocols
+[install]
+install_scripts=$base/lib/industrial_protocols


### PR DESCRIPTION
## Summary
- add setup.cfg for the industrial_protocols package

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869440336f0833182902464ec2b36e9