### PR TITLE
Add script for generating setup.cfg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ From the repository root, build all packages via the meta-package:
 
 ```bash
 pip install -r requirements.txt
+# generate setup.cfg files for ROS 2 Python packages
+./create_setup_cfgs.sh
 colcon build --packages-select industrial_robotics_simulation_platform_meta
 source install/setup.bash
 ```

--- a/create_setup_cfgs.sh
+++ b/create_setup_cfgs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+WORKSPACE_ROOT="$(pwd)"
+SRC_DIR="$WORKSPACE_ROOT/src"
+
+echo "Searching for Python ROS 2 packages in $SRC_DIR..."
+
+for setup_py in $(find "$SRC_DIR" -mindepth 2 -maxdepth 3 -name 'setup.py'); do
+    PKG_DIR="$(dirname "$setup_py")"
+    PKG_NAME="$(basename "$PKG_DIR")"
+    SETUP_CFG="$PKG_DIR/setup.cfg"
+
+    if [[ -f "$SETUP_CFG" ]]; then
+        echo "  [$PKG_NAME] setup.cfg already exists, skipping."
+        continue
+    fi
+
+    echo "  [$PKG_NAME] Creating $SETUP_CFG ..."
+    cat <<EOF_INNER > "$SETUP_CFG"
+[develop]
+script_dir=\$base/lib/$PKG_NAME
+[install]
+install_scripts=\$base/lib/$PKG_NAME
+EOF_INNER
+
+done
+
+echo "All done!"

--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -18,6 +18,7 @@ sudo apt install python3-rosdep
 sudo rosdep init
 rosdep update
 rosdep install --from-paths src -y --ignore-src
+./create_setup_cfgs.sh
 colcon build --symlink-install
 source install/setup.bash
 ```


### PR DESCRIPTION
## Summary
- add `create_setup_cfgs.sh` to generate `setup.cfg` in ROS 2 Python packages
- document how to run the new helper script

## Testing
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6869441bc6f08331bbef6e0c99e65193