### PR TITLE
Allow camera config override

### DIFF
--- a/src/simulation_tools/README.md
+++ b/src/simulation_tools/README.md
@@ -22,3 +22,8 @@ Other launches include `realsense_hybrid_launch.py` for RealSense cameras and `v
 
 ## Extension
 Pass `-h` to any launch file to see configurable arguments and adapt them to your needs.
+
+Both `integrated_system_launch.py` and `realsense_hybrid_launch.py` accept a
+`camera_config` argument that points to a YAML file with parameters for the
+`realsense2_camera` node. The default is the sample configuration in
+`simulation_core/config/realsense_config.yaml`.

--- a/src/simulation_tools/launch/integrated_system_launch.py
+++ b/src/simulation_tools/launch/integrated_system_launch.py
@@ -29,6 +29,14 @@ def generate_launch_description():
             'config',
         ),
     )
+    camera_config = LaunchConfiguration(
+        'camera_config',
+        default=os.path.join(
+            get_package_share_directory('simulation_core'),
+            'config',
+            'realsense_config.yaml',
+        ),
+    )
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
     save_images = LaunchConfiguration('save_images', default='false')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
@@ -55,6 +63,15 @@ def generate_launch_description():
                 'config',
             ),
             description='Directory containing configuration files',
+        ),
+        DeclareLaunchArgument(
+            'camera_config',
+            default_value=os.path.join(
+                get_package_share_directory('simulation_core'),
+                'config',
+                'realsense_config.yaml',
+            ),
+            description='YAML file with parameters for the RealSense camera',
         ),
         DeclareLaunchArgument(
             'data_dir',
@@ -87,18 +104,7 @@ def generate_launch_description():
             package='realsense2_camera',
             executable='realsense2_camera_node',
             name='realsense2_camera',
-            parameters=[{
-                'enable_color': True,
-                'enable_depth': True,
-                'enable_infra1': False,
-                'enable_infra2': False,
-                'color_width': 640,
-                'color_height': 480,
-                'depth_width': 640,
-                'depth_height': 480,
-                'depth_fps': 30,
-                'color_fps': 30
-            }],
+            parameters=[camera_config],
             output='screen',
             condition=IfCondition(use_realsense)
         )

--- a/src/simulation_tools/launch/realsense_hybrid_launch.py
+++ b/src/simulation_tools/launch/realsense_hybrid_launch.py
@@ -12,8 +12,19 @@ from ament_index_python.packages import get_package_share_directory
 def generate_launch_description():
     # Declare launch arguments
     # Launch parameters
-    config_dir = LaunchConfiguration('config_dir', default=os.path.join(
-        get_package_share_directory('simulation_core'), 'config'))
+    config_dir = LaunchConfiguration(
+        'config_dir',
+        default=os.path.join(
+            get_package_share_directory('simulation_core'), 'config')
+    )
+    camera_config = LaunchConfiguration(
+        'camera_config',
+        default=os.path.join(
+            get_package_share_directory('simulation_core'),
+            'config',
+            'realsense_config.yaml',
+        ),
+    )
     data_dir = LaunchConfiguration('data_dir', default='/tmp/simulation_data')
     save_images = LaunchConfiguration('save_images', default='false')
     allow_unsafe_werkzeug = LaunchConfiguration('allow_unsafe_werkzeug', default='true')
@@ -45,6 +56,13 @@ def generate_launch_description():
             default_value=os.path.join(get_package_share_directory('simulation_core'), 'config'),
             description='Directory containing configuration files'),
         DeclareLaunchArgument(
+            'camera_config',
+            default_value=os.path.join(
+                get_package_share_directory('simulation_core'),
+                'config',
+                'realsense_config.yaml'),
+            description='YAML file with parameters for the RealSense camera'),
+        DeclareLaunchArgument(
             'data_dir',
             default_value='/tmp/simulation_data',
             description='Directory for storing data and exports'),
@@ -71,18 +89,7 @@ def generate_launch_description():
             package='realsense2_camera',
             executable='realsense2_camera_node',
             name='realsense2_camera',
-            parameters=[{
-                'enable_color': True,
-                'enable_depth': True,
-                'enable_infra1': False,
-                'enable_infra2': False,
-                'color_width': 640,
-                'color_height': 480,
-                'depth_width': 640,
-                'depth_height': 480,
-                'depth_fps': 30,
-                'color_fps': 30
-            }],
+            parameters=[camera_config],
             output='screen'
         )
     )


### PR DESCRIPTION
## Summary
- add `camera_config` argument to camera-based launch files
- wire up camera node to use the provided config YAML
- document new argument in simulation_tools README

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68698ee65aac833191d59f0c35c7c3d9