### PR TITLE
Fix docs conf imports

### DIFF
--- a/docs/api/source/conf.py
+++ b/docs/api/source/conf.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -12,9 +15,6 @@ author = 'Industrial Robotics Team'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
-import os
-import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', 'src')))
 
@@ -31,8 +31,6 @@ autodoc_default_options = {
     'undoc-members': True,
     'show-inheritance': True,
 }
-
-
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output


### PR DESCRIPTION
## Summary
- move os and sys imports above comment block in Sphinx `conf.py`
- tighten spacing before HTML options section

## Testing
- `flake8 docs/api/source/conf.py`
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686996300fe883318800f50e77440532