### PR TITLE
Fix indentation in benchmark_perception list comprehension

### DIFF
--- a/scripts/benchmark_perception.py
+++ b/scripts/benchmark_perception.py
@@ -107,9 +107,15 @@ def evaluate_detections(gt_list, pred_list, num_classes, iou_thresh=0.5):
         for idx, (img_idx, pred) in enumerate(image_preds):
             gts = cls_gts[img_idx]
             ious = [
-                iou(pred["box"], [gt["bbox"][0], gt["bbox"][1],
-                                     gt["bbox"][0] + gt["bbox"][2],
-                                     gt["bbox"][1] + gt["bbox"][3]])
+                iou(
+                    pred["box"],
+                    [
+                        gt["bbox"][0],
+                        gt["bbox"][1],
+                        gt["bbox"][0] + gt["bbox"][2],
+                        gt["bbox"][1] + gt["bbox"][3],
+                    ],
+                )
                 for gt in gts
             ]
             if ious and max(ious) >= iou_thresh:


### PR DESCRIPTION
## Summary
- adjust indentation of list comprehension in `benchmark_perception.py`
- ensure flake8 passes for this script

## Testing
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6869963171748331b8583b09e116103c