### PR TITLE
Ensure logger closed on web interface shutdown

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -903,6 +903,7 @@ class WebInterfaceNode(Node):
 
     def shutdown(self) -> None:
         """Stop the Socket.IO server and wait for its thread to finish."""
+        self.action_logger.close()
         try:
             self.socketio.stop()
         except Exception as e:  # pragma: no cover - best effort shutdown


### PR DESCRIPTION
## Summary
- close action logger in `WebInterfaceNode.shutdown`
- test that shutdown closes the logger

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869965e06bc833189a9897d1e17b9ae