### PR TITLE
Fix limit validation for actions API

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -699,6 +699,8 @@ class WebInterfaceNode(Node):
                 limit = int(limit_str)
             except ValueError:
                 return jsonify({'error': 'Invalid limit parameter'}), 400
+            if limit <= 0:
+                return jsonify({'error': 'Invalid limit parameter'}), 400
 
             rows = []
             try:


### PR DESCRIPTION
## Summary
- reject non-positive values in `api/actions`

## Testing
- `flake8 src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869966fa4bc8331a299867199c9430c