### PR TITLE
Fix jog validation

### DIFF
--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -35,6 +35,7 @@ import numpy as np
 import base64
 
 SCENARIO_ID_PATTERN = re.compile(r'^[A-Za-z0-9_]+$')
+JOINT_PATTERN = re.compile(r'^[A-Za-z0-9_]+$')
 
 from ament_index_python.packages import get_package_share_directory
 from .action_logger import ActionLogger
@@ -666,10 +667,18 @@ class WebInterfaceNode(Node):
             if joint is None or delta is None:
                 return jsonify({'error': 'joint and delta required'}), 400
 
+            if not JOINT_PATTERN.match(str(joint)):
+                return jsonify({'error': 'invalid joint'}), 400
+
+            try:
+                delta_val = float(delta)
+            except (TypeError, ValueError):
+                return jsonify({'error': 'invalid delta'}), 400
+
             cmd_msg = String()
-            cmd_msg.data = f'jog {joint} {delta}'
+            cmd_msg.data = f'jog {joint} {delta_val}'
             self.command_pub.publish(cmd_msg)
-            self.action_logger.log('jog', {'joint': joint, 'delta': delta})
+            self.action_logger.log('jog', {'joint': joint, 'delta': delta_val})
             return jsonify({'success': True})
 
         @self.app.route('/api/waypoint', methods=['POST'])

--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -257,6 +257,46 @@ def test_jog_api_publishes(monkeypatch):
     logger_mock.log.assert_called_once_with('jog', {'joint': 1, 'delta': 0.1})
 
 
+def test_jog_api_invalid_delta(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+    _login(client)
+
+    res = client.post('/api/jog', json={'joint': 'j1', 'delta': 'bad'})
+    assert res.status_code == 400
+
+
+def test_jog_api_invalid_joint(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    client = node.app.test_client()
+    _login(client)
+
+    res = client.post('/api/jog', json={'joint': '..bad', 'delta': 0.1})
+    assert res.status_code == 400
+
+
 def test_waypoint_api_execute(monkeypatch):
     _setup_ros_stubs(monkeypatch)
 


### PR DESCRIPTION
## Summary
- validate joint name and delta in `/api/jog`
- test jog validation failures

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869967c81ac8331afe3227222fc5b44