### PR TITLE
Add robot interface implementations

### DIFF
--- a/src/robot_interfaces/robot_interfaces/delta_interface/__init__.py
+++ b/src/robot_interfaces/robot_interfaces/delta_interface/__init__.py
@@ -1,1 +1,35 @@
 """Delta robot specific interface helpers."""
+
+from rclpy.node import Node
+from std_msgs.msg import String
+from sensor_msgs.msg import JointState
+from typing import Dict
+
+
+class DeltaInterface:
+    """Simple interface for publishing commands and reading status."""
+
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.command_pub = node.create_publisher(String, "/simulation/command", 10)
+        self.status_sub = node.create_subscription(
+            String, "/simulation/status", self._status_callback, 10
+        )
+        self.last_status = ""
+
+    def _status_callback(self, msg: String) -> None:
+        self.last_status = msg.data
+
+    def send_command(self, command: str) -> None:
+        msg = String()
+        msg.data = command
+        self.command_pub.publish(msg)
+
+    def get_status(self) -> str:
+        return self.last_status
+
+    @staticmethod
+    def convert_joint_state(msg: JointState) -> Dict[str, float]:
+        """Return joint name to position mapping."""
+        return {n: p for n, p in zip(msg.name, msg.position)}
+

--- a/src/robot_interfaces/robot_interfaces/ur5_interface/__init__.py
+++ b/src/robot_interfaces/robot_interfaces/ur5_interface/__init__.py
@@ -1,1 +1,34 @@
 """UR5 robot interface helpers."""
+
+from rclpy.node import Node
+from std_msgs.msg import String
+from sensor_msgs.msg import JointState
+from typing import Dict
+
+
+class UR5Interface:
+    """Interface for sending commands to a UR5 robot."""
+
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.command_pub = node.create_publisher(String, "/simulation/command", 10)
+        self.status_sub = node.create_subscription(
+            String, "/simulation/status", self._status_callback, 10
+        )
+        self.last_status = ""
+
+    def _status_callback(self, msg: String) -> None:
+        self.last_status = msg.data
+
+    def send_command(self, command: str) -> None:
+        msg = String()
+        msg.data = command
+        self.command_pub.publish(msg)
+
+    def get_status(self) -> str:
+        return self.last_status
+
+    @staticmethod
+    def convert_joint_state(msg: JointState) -> Dict[str, float]:
+        return {n: p for n, p in zip(msg.name, msg.position)}
+

--- a/src/robot_interfaces/setup.py
+++ b/src/robot_interfaces/setup.py
@@ -16,4 +16,10 @@ setup(
     maintainer_email='user@example.com',
     description='Robot specific interfaces',
     license='Apache-2.0',
+    entry_points={
+        'simulation_core.robots': [
+            'delta = robot_interfaces.delta_interface:DeltaInterface',
+            'ur5 = robot_interfaces.ur5_interface:UR5Interface',
+        ],
+    },
 )

--- a/tests/test_robot_interfaces.py
+++ b/tests/test_robot_interfaces.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from pathlib import Path
+from test_utils import _setup_ros_stubs
 
 # Ensure packages under src/ are importable
 ROOT = Path(__file__).resolve().parents[1]
@@ -8,11 +9,68 @@ sys.path.append(str(ROOT / 'src'))
 sys.path.append(str(ROOT / 'src' / 'robot_interfaces'))
 
 
-def test_delta_interface_docstring():
+def test_delta_interface_docstring(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    sys.modules.pop('robot_interfaces.delta_interface', None)
     mod = importlib.import_module('robot_interfaces.delta_interface')
     assert mod.__doc__ == 'Delta robot specific interface helpers.'
 
 
-def test_ur5_interface_docstring():
+def test_ur5_interface_docstring(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    sys.modules.pop('robot_interfaces.ur5_interface', None)
     mod = importlib.import_module('robot_interfaces.ur5_interface')
     assert mod.__doc__ == 'UR5 robot interface helpers.'
+
+
+def _msg(data: str):
+    from std_msgs.msg import String
+
+    m = String()
+    m.data = data
+    return m
+
+
+def test_delta_interface_send_command(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    sys.modules.pop('robot_interfaces.delta_interface', None)
+    from robot_interfaces.delta_interface import DeltaInterface
+    from rclpy.node import Node
+
+    node = Node()
+    iface = DeltaInterface(node)
+
+    iface.command_pub.publish.reset_mock()
+    iface.send_command('start')
+    iface.command_pub.publish.assert_called_once()
+    out = iface.command_pub.publish.call_args[0][0]
+    assert out.data == 'start'
+
+    iface._status_callback(_msg('running'))
+    assert iface.get_status() == 'running'
+
+    from sensor_msgs.msg import JointState
+
+    js = JointState()
+    js.name = ['j1']
+    js.position = [1.0]
+    assert DeltaInterface.convert_joint_state(js) == {'j1': 1.0}
+
+
+def test_ur5_interface_send_command(monkeypatch):
+    _setup_ros_stubs(monkeypatch)
+    sys.modules.pop('robot_interfaces.ur5_interface', None)
+    from robot_interfaces.ur5_interface import UR5Interface
+    from rclpy.node import Node
+
+    node = Node()
+    iface = UR5Interface(node)
+
+    iface.command_pub.publish.reset_mock()
+    iface.send_command('stop')
+    iface.command_pub.publish.assert_called_once()
+    out = iface.command_pub.publish.call_args[0][0]
+    assert out.data == 'stop'
+
+    iface._status_callback(_msg('idle'))
+    assert iface.get_status() == 'idle'


### PR DESCRIPTION
## Summary
- implement `DeltaInterface` and `UR5Interface` with simple ROS2 helpers
- register the interfaces via entry points
- test command publication and status handling

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751db46d9c8331b5098dbe44b74f00