### PR TITLE
Extend error simulation

### DIFF
--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -112,6 +112,16 @@ You can also change the value at runtime by publishing a configuration message:
 ros2 topic pub /simulation/config std_msgs/msg/String '{"settings": {"simulation": {"error_simulation_rate": 0.5}}}'
 ```
 
+### Supported Error Types
+
+The environment configurator recognizes the following error types:
+
+- `gripper_failure` – gripper fails to grasp an object
+- `object_slip` – object slips from the gripper
+- `sensor_noise` – temporary sensor inaccuracy
+- `communication_delay` – delayed control communication increases cycle time
+- `power_fluctuation` – power instability reduces throughput
+
 ## 8. Adjusting Camera FPS
 
 The camera simulator defaults to the frame rate specified in `src/simulation_core/config/default_camera_config.yaml`. You can override this when launching the synthetic camera node. For example:

--- a/src/simulation_core/simulation_core/environment_configurator_node.py
+++ b/src/simulation_core/simulation_core/environment_configurator_node.py
@@ -446,13 +446,25 @@ class EnvironmentConfiguratorNode(Node):
     def simulate_error(self, error_type: str) -> None:
         if not self.running:
             return
-        
+
         self.get_logger().info(f'Simulating error: {error_type}')
-        
+
+        # Pick a random error type if requested
+        if error_type == 'random':
+            error_type = random.choice(
+                [
+                    'gripper_failure',
+                    'object_slip',
+                    'sensor_noise',
+                    'communication_delay',
+                    'power_fluctuation',
+                ]
+            )
+
         # Update metrics
         if self.record_metrics:
             self.metrics['errors'] += 1
-            
+
             # Different error types affect different metrics
             if error_type == 'gripper_failure':
                 self.metrics['accuracy'] = max(0.0, self.metrics['accuracy'] - 5.0)
@@ -460,6 +472,12 @@ class EnvironmentConfiguratorNode(Node):
                 self.metrics['accuracy'] = max(0.0, self.metrics['accuracy'] - 3.0)
             elif error_type == 'sensor_noise':
                 self.metrics['accuracy'] = max(0.0, self.metrics['accuracy'] - 2.0)
+            elif error_type == 'communication_delay':
+                self.metrics['cycle_time'] += 1.0
+            elif error_type == 'power_fluctuation':
+                self.metrics['throughput'] = max(
+                    0.0, self.metrics['throughput'] * 0.8
+                )
     
     def publish_status(self) -> None:
         status_msg = String()

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -410,3 +410,24 @@ def test_simulate_error_updates_metrics(tmp_path):
 
     assert dummy.metrics['errors'] == 1
     assert dummy.metrics['accuracy'] == 95.0
+
+
+def test_simulate_new_error_types(tmp_path):
+    dummy = make_dummy(tmp_path)
+    dummy.record_metrics = True
+    dummy.metrics = {
+        'cycle_time': 2.0,
+        'throughput': 60.0,
+        'accuracy': 100.0,
+        'errors': 0,
+        'objects_processed': 0,
+    }
+    dummy.running = True
+
+    ec.EnvironmentConfiguratorNode.simulate_error(dummy, 'communication_delay')
+    assert dummy.metrics['errors'] == 1
+    assert dummy.metrics['cycle_time'] == 3.0
+
+    ec.EnvironmentConfiguratorNode.simulate_error(dummy, 'power_fluctuation')
+    assert dummy.metrics['errors'] == 2
+    assert dummy.metrics['throughput'] == pytest.approx(48.0)


### PR DESCRIPTION
## Summary
- expand supported error types in `simulate_error`
- list all supported error types in the full system guide
- cover new error cases with tests

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751dba7e988331923f6a5d8bb6a76d