### PR TITLE
Add joint state plotter node

### DIFF
--- a/docs/full_system_run_guide.md
+++ b/docs/full_system_run_guide.md
@@ -72,7 +72,15 @@ Open another terminal for RViz to view the UR5 model and camera feeds:
 ros2 launch ur5_robot_description display.launch.py
 ```
 
-## 5. (Optional) Run Gazebo
+## 5. View Joint State Plots
+
+Start a Matplotlib window that displays joint angles in real time:
+
+```bash
+ros2 launch simulation_tools visualization_launch.py use_joint_plotter:=true
+```
+
+## 6. (Optional) Run Gazebo
 
 To see the robot in a physics simulation, start Gazebo in a separate terminal:
 
@@ -87,13 +95,13 @@ ros2 run gazebo_ros spawn_entity.py \
     -topic /robot_description -entity ur5
 ```
 
-## 6. Access the Web Interface
+## 7. Access the Web Interface
 
 Navigate to [http://localhost:8080](http://localhost:8080) in your browser to control the simulation, add objects and monitor status.
 
 The full system is now running with Gazebo, RViz, object detection and the web dashboard.
 
-## 7. Adjust Error Simulation Rate
+## 8. Adjust Error Simulation Rate
 
 The environment configurator node can randomly trigger errors during metrics
 updates. Control how often this happens using the `error_simulation_rate`
@@ -112,7 +120,7 @@ You can also change the value at runtime by publishing a configuration message:
 ros2 topic pub /simulation/config std_msgs/msg/String '{"settings": {"simulation": {"error_simulation_rate": 0.5}}}'
 ```
 
-## 8. Adjusting Camera FPS
+## 9. Adjusting Camera FPS
 
 The camera simulator defaults to the frame rate specified in `src/simulation_core/config/default_camera_config.yaml`. You can override this when launching the synthetic camera node. For example:
 

--- a/src/simulation_tools/README.md
+++ b/src/simulation_tools/README.md
@@ -18,7 +18,7 @@ Start the full system:
 ros2 launch simulation_tools integrated_system_launch.py
 ```
 
-Other launches include `realsense_hybrid_launch.py` for RealSense cameras and `visualization_launch.py` for a standalone visualization server.
+Other launches include `realsense_hybrid_launch.py` for RealSense cameras and `visualization_launch.py` for a standalone visualization server. The latter accepts `use_joint_plotter:=true` to show live joint plots.
 
 ## Extension
 Pass `-h` to any launch file to see configurable arguments and adapt them to your needs.

--- a/src/simulation_tools/launch/visualization_launch.py
+++ b/src/simulation_tools/launch/visualization_launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
     use_delta_robot = LaunchConfiguration("use_delta_robot")
     use_ur5_robot = LaunchConfiguration("use_ur5_robot")
     use_sim_time = LaunchConfiguration("use_sim_time")
+    use_joint_plotter = LaunchConfiguration("use_joint_plotter")
     # Get package directories
     simulation_tools_dir = get_package_share_directory('simulation_tools')
     delta_desc_dir = get_package_share_directory('delta_robot_description')
@@ -55,6 +56,12 @@ def generate_launch_description():
         'use_rviz',
         default_value='true',
         description='Launch RViz for visualization'
+    ))
+
+    ld.add_action(DeclareLaunchArgument(
+        'use_joint_plotter',
+        default_value='false',
+        description='Launch joint plotter for /joint_states'
     ))
 
     ld.add_action(DeclareLaunchArgument(
@@ -134,6 +141,15 @@ def generate_launch_description():
         condition=IfCondition(use_ur5_robot),
     )
     ld.add_action(ur5_joint_state_publisher)
+
+    joint_plotter_node = Node(
+        package='simulation_tools',
+        executable='joint_plotter',
+        name='joint_plotter',
+        output='screen',
+        condition=IfCondition(use_joint_plotter),
+    )
+    ld.add_action(joint_plotter_node)
 
     # Include realsense launch file conditionally
     realsense_launch_file = os.path.join(

--- a/src/simulation_tools/setup.py
+++ b/src/simulation_tools/setup.py
@@ -37,6 +37,7 @@ setup(
     entry_points={
         'console_scripts': [
             'object_3d_viewer = simulation_tools.object_3d_viewer_node:main',
+            'joint_plotter = simulation_tools.joint_plotter_node:main',
         ]
     },
 )

--- a/src/simulation_tools/simulation_tools/__init__.py
+++ b/src/simulation_tools/simulation_tools/__init__.py
@@ -1,5 +1,9 @@
 """Utility nodes for simulation tools."""
 
-__all__ = ['Object3DViewerNode']
+__all__ = [
+    'Object3DViewerNode',
+    'JointPlotterNode',
+]
 
 from .object_3d_viewer_node import Object3DViewerNode
+from .joint_plotter_node import JointPlotterNode

--- a/src/simulation_tools/simulation_tools/joint_plotter_node.py
+++ b/src/simulation_tools/simulation_tools/joint_plotter_node.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""ROS2 node plotting joint state positions in real time."""
+
+from __future__ import annotations
+
+import threading
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from matplotlib import pyplot as plt
+
+
+class JointPlotterNode(Node):
+    """Subscribe to `/joint_states` and plot joint positions."""
+
+    def __init__(self) -> None:
+        super().__init__("joint_plotter_node")
+
+        self.declare_parameter("joint_states_topic", "/joint_states")
+        topic = self.get_parameter("joint_states_topic").value
+
+        self._lock = threading.Lock()
+        self._names: list[str] = []
+        self._positions: list[list[float]] = []
+        self._times: list[float] = []
+
+        self.create_subscription(JointState, topic, self.joint_callback, 10)
+
+        plt.ion()
+        self._fig, self._ax = plt.subplots()
+        self._timer = self.create_timer(0.5, self.update_plot)
+
+        self.get_logger().info("Joint plotter node initialized")
+
+    def joint_callback(self, msg: JointState) -> None:
+        with self._lock:
+            if not self._names:
+                self._names = list(msg.name)
+            self._times.append(self.get_clock().now().nanoseconds / 1e9)
+            self._positions.append(list(msg.position))
+
+    def update_plot(self) -> None:
+        with self._lock:
+            if not self._times or not self._names:
+                return
+            times = self._times
+            data = list(zip(*self._positions))
+            self._ax.clear()
+            for idx, series in enumerate(data):
+                label = self._names[idx] if idx < len(self._names) else f"joint{idx}"
+                self._ax.plot(times, series, label=label)
+            self._ax.set_xlabel("Time (s)")
+            self._ax.set_ylabel("Position (rad)")
+            self._ax.legend()
+        self._fig.canvas.draw()
+        self._fig.canvas.flush_events()
+
+
+def main(args: list[str] | None = None) -> None:
+    rclpy.init(args=args)
+    node = JointPlotterNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -106,3 +106,11 @@ def test_industrial_protocol_bridge_defaults(monkeypatch):
     assert node.get_parameter('modbus_host').value == 'localhost'
     assert node.get_parameter('modbus_port').value == 502
     assert node.get_parameter('modbus_enabled').value is False
+
+
+def test_joint_plotter_node_defaults():
+    from simulation_tools.joint_plotter_node import JointPlotterNode
+
+    node = _init_node(JointPlotterNode)
+
+    assert node.get_parameter('joint_states_topic').value == '/joint_states'


### PR DESCRIPTION
## Summary
- add `JointPlotterNode` for live joint plots
- expose `joint_plotter` entry point
- allow enabling the plotter via `visualization_launch.py`
- document new plot viewer in package README and full system guide
- test default parameters for `JointPlotterNode`

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875269db9708331b4e15ab0f5542a73