### PR TITLE
Add environment viewer for control page

### DIFF
--- a/docs/ui_customization.md
+++ b/docs/ui_customization.md
@@ -27,6 +27,16 @@ style of individual views.
    templates to inject scripts, extra CSS or content sections. Use these blocks
    to add widgets to any page.
 
+### Environment Viewer
+
+The control page includes a Three.js viewer showing the layout of the current
+scenario. The viewer is rendered inside the `env-canvas` element and is driven
+by `/static/env_viewer.js`. Geometry is loaded from the backend via the
+`/api/environment` endpoint which returns the `environment`, `objects`,
+`containers` and `conveyors` sections of the active scenario file. Modifying
+these fields in your scenario YAML will automatically change what the viewer
+displays.
+
 After modifying the templates, rebuild the `web_interface_frontend` package
 using `colcon build --packages-select web_interface_frontend` so the updated
 files are installed.

--- a/src/web_interface_backend/web_interface_backend/web_interface_node.py
+++ b/src/web_interface_backend/web_interface_backend/web_interface_node.py
@@ -358,6 +358,26 @@ class WebInterfaceNode(Node):
                     self.get_logger().error(f'Error loading users: {e}')
         return {'admin': 'admin'}
 
+    def _load_environment_config(self) -> dict | None:
+        """Load environment geometry from the current scenario file."""
+        if not self.config_dir or not self.current_scenario:
+            return None
+        for ext in ('yaml', 'json'):
+            path = os.path.join(self.config_dir, f'{self.current_scenario}.{ext}')
+            if os.path.exists(path):
+                try:
+                    with open(path, 'r', encoding='utf-8') as f:
+                        if ext == 'json':
+                            data = json.load(f)
+                        else:
+                            data = yaml.safe_load(f)
+                    if isinstance(data, dict):
+                        env_keys = ['environment', 'objects', 'containers', 'conveyors']
+                        return {k: data.get(k) for k in env_keys if k in data}
+                except Exception as e:  # pragma: no cover - log and ignore
+                    self.get_logger().error(f'Error loading environment: {e}')
+        return None
+
     def setup_routes(self) -> None:
         """Register Flask HTTP routes for the user interface."""
         @self.app.route('/login', methods=['GET', 'POST'])
@@ -486,6 +506,14 @@ class WebInterfaceNode(Node):
         @login_required
         def get_objects():
             return jsonify({'objects': self.latest_objects})
+
+        @self.app.route('/api/environment')
+        @login_required
+        def get_environment():
+            env = self._load_environment_config()
+            if env is None:
+                return jsonify({'error': 'Environment not available'}), 404
+            return jsonify({'environment': env})
         
         @self.app.route('/api/scenarios')
         @login_required

--- a/src/web_interface_frontend/static/env_viewer.js
+++ b/src/web_interface_frontend/static/env_viewer.js
@@ -1,0 +1,80 @@
+var EnvViewer = (function () {
+    let scene, camera, renderer, canvas;
+    function init(canvasElem) {
+        canvas = canvasElem;
+        scene = new THREE.Scene();
+        const width = canvas.clientWidth;
+        const height = canvas.clientHeight;
+        camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 100);
+        camera.position.set(1.5, 1.5, 1.5);
+        camera.lookAt(0, 0, 0);
+        renderer = new THREE.WebGLRenderer({ canvas: canvas });
+        renderer.setSize(width, height);
+        const light = new THREE.DirectionalLight(0xffffff, 1);
+        light.position.set(2, 2, 2);
+        scene.add(light);
+        scene.add(new THREE.GridHelper(2, 10));
+        animate();
+    }
+    function animate() {
+        requestAnimationFrame(animate);
+        if (renderer && scene && camera) {
+            renderer.render(scene, camera);
+        }
+    }
+    function clearScene() {
+        if (!scene) return;
+        while (scene.children.length > 0) {
+            scene.remove(scene.children.pop());
+        }
+        const light = new THREE.DirectionalLight(0xffffff, 1);
+        light.position.set(2, 2, 2);
+        scene.add(light);
+        scene.add(new THREE.GridHelper(2, 10));
+    }
+    function buildEnvironment(env) {
+        clearScene();
+        if (!env) return;
+        const material = new THREE.MeshLambertMaterial({ color: 0xcccccc });
+        (env.objects || []).forEach(obj => {
+            const d = obj.dimensions || [0.1, 0.1, 0.1];
+            const geo = new THREE.BoxGeometry(d[0], d[1], d[2]);
+            const mesh = new THREE.Mesh(geo, material);
+            const p = obj.position || [0, 0, 0];
+            mesh.position.set(p[0], p[1], p[2]);
+            scene.add(mesh);
+        });
+        (env.containers || []).forEach(obj => {
+            const d = obj.dimensions || [0.1, 0.1, 0.1];
+            const geo = new THREE.BoxGeometry(d[0], d[1], d[2]);
+            const mesh = new THREE.Mesh(geo, material);
+            const p = obj.position || [0, 0, 0];
+            mesh.position.set(p[0], p[1], p[2]);
+            scene.add(mesh);
+        });
+        (env.conveyors || []).forEach(obj => {
+            const d = obj.dimensions || [0.1, 0.1, 0.1];
+            const geo = new THREE.BoxGeometry(d[0], d[1], d[2]);
+            const mesh = new THREE.Mesh(geo, material);
+            const p = obj.position || [0, 0, 0];
+            mesh.position.set(p[0], p[1], p[2]);
+            scene.add(mesh);
+        });
+    }
+    function updateObjects(objects) {
+        if (!scene) return;
+        const material = new THREE.MeshNormalMaterial();
+        objects.forEach(obj => {
+            const geo = new THREE.BoxGeometry(0.05, 0.05, 0.05);
+            const mesh = new THREE.Mesh(geo, material);
+            mesh.position.set(obj.position.x, obj.position.y, obj.position.z);
+            scene.add(mesh);
+        });
+    }
+    function loadEnvironment() {
+        fetch('/api/environment').then(r => r.json()).then(data => {
+            buildEnvironment(data.environment);
+        }).catch(() => {});
+    }
+    return { init, loadEnvironment, updateObjects };
+})();

--- a/src/web_interface_frontend/templates/control.html
+++ b/src/web_interface_frontend/templates/control.html
@@ -166,6 +166,7 @@
 </div>
 {% endblock %}
 {% block scripts %}
+<script src="/static/env_viewer.js"></script>
 <script>
 const socket = io();
 const statusBadge = document.getElementById('status-badge');
@@ -194,34 +195,8 @@ const clearWaypointsBtn = document.getElementById('clear-waypoints');
 const executeSequenceBtn = document.getElementById('execute-sequence');
 const ctx = workspaceCanvas.getContext('2d');
 let objects = [];
-let scene, camera, renderer;
 const envCanvas = document.getElementById('env-canvas');
-function initThree() {
-    scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(75, envCanvas.clientWidth/envCanvas.clientHeight, 0.1, 1000);
-    renderer = new THREE.WebGLRenderer({canvas: envCanvas});
-    renderer.setSize(envCanvas.clientWidth, envCanvas.clientHeight);
-    camera.position.z = 2;
-    const light = new THREE.DirectionalLight(0xffffff, 1);
-    light.position.set(0,0,2).add(new THREE.Vector3(1,1,1));
-    scene.add(light);
-    animate();
-}
-function animate(){
-    requestAnimationFrame(animate);
-    renderer.render(scene, camera);
-}
-function updateThreeObjects(){
-    if(!scene)return;
-    scene.clear();
-    const material = new THREE.MeshNormalMaterial();
-    objects.forEach(o=>{
-        const geo = new THREE.BoxGeometry(0.05,0.05,0.05);
-        const mesh = new THREE.Mesh(geo, material);
-        mesh.position.set(o.position.x,o.position.y,o.position.z);
-        scene.add(mesh);
-    });
-}
+EnvViewer.init(envCanvas);
 socket.on('status_update', function(data) {
     statusBadge.textContent = data.status;
     statusBadge.className = 'badge';
@@ -244,13 +219,14 @@ socket.on('status_update', function(data) {
             statusBadge.classList.add('bg-secondary');
     }
     addToCommandLog(`Status: ${data.status}`);
+    EnvViewer.loadEnvironment();
 });
 socket.on('objects_update', function(data) {
     objects = data.objects;
     objectsCount.textContent = objects.length;
     updateObjectDropdown();
     drawWorkspace();
-    updateThreeObjects();
+    EnvViewer.updateObjects(objects);
 });
 socket.on('image_data', function(data) {
     if (data.rgb && rgbImage) {
@@ -463,7 +439,7 @@ function sendCommand(cmd) {
         body: JSON.stringify({ command: cmd })
     }).then(() => addToCommandLog('Command: ' + cmd));
 }
-initThree();
+EnvViewer.loadEnvironment();
 loadScenarios();
 loadExports();
 drawWorkspace();

--- a/tests/test_web_interface_api.py
+++ b/tests/test_web_interface_api.py
@@ -297,6 +297,54 @@ def test_jog_api_invalid_joint(monkeypatch):
     assert res.status_code == 400
 
 
+def test_environment_api(monkeypatch, tmp_path):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    node.config_dir = str(tmp_path)
+    node.current_scenario = 'test'
+    (tmp_path / 'test.yaml').write_text(
+        'environment:\n  size: [1,1,1]\nobjects:\n - id: a\n   position: [0,0,0]\n   dimensions: [1,1,1]'
+    )
+    client = node.app.test_client()
+    _login(client)
+    res = client.get('/api/environment')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert 'environment' in data
+    assert 'objects' in data['environment']
+
+
+def test_environment_api_missing(monkeypatch, tmp_path):
+    _setup_ros_stubs(monkeypatch)
+
+    sys.modules.pop('web_interface_backend.web_interface_node', None)
+
+    from web_interface_backend import web_interface_node as win
+    import flask
+    win.Flask = flask.Flask
+
+    monkeypatch.setattr(win, 'ActionLogger', MagicMock())
+    monkeypatch.setattr(win.WebInterfaceNode, 'run_server', lambda self: None)
+
+    node = win.WebInterfaceNode()
+    node.config_dir = str(tmp_path)
+    node.current_scenario = 'missing'
+    client = node.app.test_client()
+    _login(client)
+    res = client.get('/api/environment')
+    assert res.status_code == 404
+
+
 def test_waypoint_api_execute(monkeypatch):
     _setup_ros_stubs(monkeypatch)
 


### PR DESCRIPTION
## Summary
- add `/api/environment` endpoint to serve scenario geometry
- implement Three.js environment viewer and object overlay
- integrate viewer into control page
- document viewer setup
- test new API

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687526a3fe408331910c43ae2831d142