### PR TITLE
Add ROS2 Humble checks in helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ launch command. It starts the simulation with a few simple flags:
 python scripts/run_sim.py --use-realsense
 ```
 
+> **Note:** The helper scripts check for a ROS 2 Humble installation. Ensure
+> you have sourced `/opt/ros/humble/setup.bash` (and built the workspace if
+> necessary) before invoking them.
+
 ## Default Credentials
 
 The web interface starts with a single account where both the username and

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,12 +1,31 @@
 #!/usr/bin/env python3
 """Launch an experiment from a configuration file."""
 
+from __future__ import annotations
+
 import argparse
 import json
-from pathlib import Path
+import os
+import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 import yaml
+
+
+def ensure_ros2_humble() -> None:
+    """Verify that the ROS 2 Humble environment is available."""
+    if shutil.which("ros2") is None:
+        sys.exit(
+            "ros2 executable not found. Source /opt/ros/humble/setup.bash before running."
+        )
+    distro = os.environ.get("ROS_DISTRO")
+    if distro and distro != "humble":
+        print(
+            f"Warning: running under ROS 2 '{distro}' (expected 'humble').",
+            file=sys.stderr,
+        )
 
 
 def load_config(path: Path) -> dict:
@@ -43,6 +62,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    ensure_ros2_humble()
+
     config = load_config(Path(args.config))
     cmd = build_command(config)
     subprocess.run(cmd, check=False)
@@ -50,3 +71,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/run_sim.py
+++ b/scripts/run_sim.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python3
 """Utility to launch the integrated simulation."""
 
+from __future__ import annotations
+
 import argparse
+import os
+import shutil
 import subprocess
+import sys
+
+
+def ensure_ros2_humble() -> None:
+    """Verify that the ROS 2 Humble environment is available."""
+    if shutil.which("ros2") is None:
+        sys.exit(
+            "ros2 executable not found. Source /opt/ros/humble/setup.bash before running."
+        )
+    distro = os.environ.get("ROS_DISTRO")
+    if distro and distro != "humble":
+        print(
+            f"Warning: running under ROS 2 '{distro}' (expected 'humble').",
+            file=sys.stderr,
+        )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Launch the full industrial simulation"
+        description="Launch the full industrial simulation",
     )
     parser.add_argument(
         "--use-realsense",
@@ -26,6 +45,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    ensure_ros2_humble()
+
     cmd = [
         "ros2",
         "launch",
@@ -40,3 +61,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/visualize_trajectory.py
+++ b/scripts/visualize_trajectory.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python3
 """Launch RViz and related visualization nodes."""
 
+from __future__ import annotations
+
 import argparse
+import os
+import shutil
 import subprocess
+import sys
+
+
+def ensure_ros2_humble() -> None:
+    """Verify that the ROS 2 Humble environment is available."""
+    if shutil.which("ros2") is None:
+        sys.exit(
+            "ros2 executable not found. Source /opt/ros/humble/setup.bash before running."
+        )
+    distro = os.environ.get("ROS_DISTRO")
+    if distro and distro != "humble":
+        print(
+            f"Warning: running under ROS 2 '{distro}' (expected 'humble').",
+            file=sys.stderr,
+        )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Visualize robot trajectory in RViz"
+        description="Visualize robot trajectory in RViz",
     )
     parser.add_argument(
         "--use-realsense",
@@ -22,6 +41,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    ensure_ros2_humble()
+
     cmd = [
         "ros2",
         "launch",
@@ -35,3 +56,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- verify ROS 2 Humble is available before running simulation helper scripts
- warn users when different ROS distro is sourced
- document Humble requirement in README and keep helper scripts executable

## Testing
- `flake8 src tests scripts/run_sim.py scripts/run_experiment.py scripts/visualize_trajectory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207f06d648331b0e778e429b7facd