### PR TITLE
Specify Python 3.10 for ROS2 packages

### DIFF
--- a/src/apm_core/setup.py
+++ b/src/apm_core/setup.py
@@ -29,6 +29,7 @@ setup(
         'onnxruntime',
         'pyyaml',
     ],
+    python_requires='>=3.10',
     zip_safe=True,
     maintainer='ubuntu',
     maintainer_email='user@example.com',

--- a/src/fmm_core/setup.py
+++ b/src/fmm_core/setup.py
@@ -16,6 +16,7 @@ setup(
         (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
     ],
     install_requires=['setuptools'],
+    python_requires='>=3.10',
     zip_safe=True,
     maintainer='ubuntu',
     maintainer_email='user@example.com',


### PR DESCRIPTION
## Summary
- enforce Python 3.10 requirement in apm_core and fmm_core packages to match ROS 2 Humble

## Testing
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207f06d648331b0e778e429b7facd