### PR TITLE
Use parameter values in APM nodes

### DIFF
--- a/src/apm_core/apm_core/image_subscriber_node.py
+++ b/src/apm_core/apm_core/image_subscriber_node.py
@@ -14,7 +14,7 @@ class ImageSubscriberNode(Node):
         
         # Declare parameters
         self.declare_parameter('image_topic', '/camera/color/image_raw')
-        image_topic = self.get_parameter('image_topic').get_parameter_value().string_value
+        image_topic = self.get_parameter('image_topic').value
         
         # Create subscription
         self.subscription = self.create_subscription(

--- a/src/apm_core/apm_core/onnx_inference_node.py
+++ b/src/apm_core/apm_core/onnx_inference_node.py
@@ -25,7 +25,7 @@ class OnnxInferenceNode(Node):
         
         # Declare parameters
         self.declare_parameter('config_file', 'default_object_detection_config.yaml')
-        config_file = self.get_parameter('config_file').get_parameter_value().string_value
+        config_file = self.get_parameter('config_file').value
         
         # Load configuration
         self.config = self.load_config(config_file)

--- a/src/apm_core/apm_core/point_cloud_subscriber_node.py
+++ b/src/apm_core/apm_core/point_cloud_subscriber_node.py
@@ -13,7 +13,7 @@ class PointCloudSubscriberNode(Node):
         
         # Declare parameters
         self.declare_parameter('pointcloud_topic', '/camera/depth/color/points')
-        pointcloud_topic = self.get_parameter('pointcloud_topic').get_parameter_value().string_value
+        pointcloud_topic = self.get_parameter('pointcloud_topic').value
         
         # Create subscription
         self.subscription = self.create_subscription(


### PR DESCRIPTION
## Summary
- update APM nodes to use `Parameter.value` for parameter retrieval, aligning with ROS 2 Humble

## Testing
- `flake8 src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207f06d648331b0e778e429b7facd